### PR TITLE
refactor(cg): decouple the leaf vocabulary from skia; lock the boundary

### DIFF
--- a/crates/grida/src/cg/types.rs
+++ b/crates/grida/src/cg/types.rs
@@ -46,12 +46,6 @@ impl Default for CGPoint {
     }
 }
 
-impl From<CGPoint> for skia_safe::Point {
-    fn from(val: CGPoint) -> Self {
-        skia_safe::Point::new(val.x, val.y)
-    }
-}
-
 /// Defines the type of masking applied to a layer.
 ///
 /// This corresponds to the CSS `mask-type` property and is related to `clip-path` functionality.
@@ -1758,7 +1752,7 @@ pub struct StyledTextRun {
     /// Per-run fill paints override.
     /// When `None`, the node-level fills are used.
     /// Uses the same [`Paint`] model as node fills — supports solid, gradient,
-    /// and image paints composited via [`crate::painter::paint::sk_paint_stack_without_images`].
+    /// and image paints composited by the painter's `sk_paint_stack_without_images` stack.
     pub fills: Option<Vec<Paint>>,
     /// Per-run stroke paints override.
     /// When `None`, no per-run stroke is applied.

--- a/crates/grida/src/shape/polygon.rs
+++ b/crates/grida/src/shape/polygon.rs
@@ -13,7 +13,10 @@ pub struct SimplePolygonShape {
 
 /// Returns a polygon path from only points.
 pub fn build_path_from_points(points: &[CGPoint]) -> skia_safe::Path {
-    let skia_points: Vec<skia_safe::Point> = points.iter().map(|&p| p.into()).collect();
+    let skia_points: Vec<skia_safe::Point> = points
+        .iter()
+        .map(|&p| skia_safe::Point::new(p.x, p.y))
+        .collect();
     skia_safe::Path::polygon(&skia_points, true, None, None)
 }
 

--- a/crates/grida/tests/cg_architecture.rs
+++ b/crates/grida/tests/cg_architecture.rs
@@ -1,0 +1,106 @@
+//! Architectural tests for the `cg` module.
+//!
+//! `cg/` is the model-agnostic leaf-type vocabulary — paints, colors,
+//! strokes, text styles, and the SVG import IR value types. It is
+//! being prepared for standalone extraction (see the legacy seam
+//! program, gridaco/nothing#28): the closed import set enforced here
+//! is exactly what the extracted crate's `Cargo.toml` would allow —
+//! `std`/`core`, `serde`, `math2`, and intra-`cg` items.
+//!
+//! In particular `cg/` must not know skia exists: conversions into
+//! `skia_safe` types belong at the consumer boundary (`shape/`,
+//! `painter/`), never on the vocabulary types themselves.
+//!
+//! When this test fails, do not loosen the rule. Either move the
+//! offending code to the right module, or restructure the import so
+//! the type doesn't cross the boundary.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CG_ROOT_REL: &str = "src/cg";
+
+/// Modules of the `grida` crate (and external deps) that the cg
+/// vocabulary must never reach into. Extraction turns each of these
+/// into a compile error; this test makes them an error today.
+const FORBIDDEN: &[&str] = &[
+    "skia_safe",
+    "crate::node",
+    "node::schema",
+    "crate::painter",
+    "crate::runtime",
+    "crate::cache",
+    "crate::layout",
+    "crate::htmlcss",
+    "crate::import",
+    "crate::io",
+    "crate::window",
+];
+
+/// Known follow-ups: file-relative paths (under `src/cg/`) where a
+/// boundary violation is acknowledged but not yet fixed. Each entry
+/// should reference an issue/comment explaining why it's deferred.
+/// Keep this list **shrinking, not growing**.
+const ALLOWLIST: &[(&str, &str)] = &[];
+
+fn cg_root() -> PathBuf {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    Path::new(manifest).join(CG_ROOT_REL)
+}
+
+fn rs_files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for ent in entries.flatten() {
+        let p = ent.path();
+        if p.is_dir() {
+            out.extend(rs_files_under(&p));
+        } else if p.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+    out
+}
+
+fn is_allowlisted(file_rel: &str, forbidden: &str) -> bool {
+    ALLOWLIST
+        .iter()
+        .any(|&(f, n)| file_rel.ends_with(f) && n == forbidden)
+}
+
+#[test]
+fn cg_imports_are_closed() {
+    let files = rs_files_under(&cg_root());
+    assert!(
+        !files.is_empty(),
+        "no .rs files found under {} — did the module move?",
+        CG_ROOT_REL
+    );
+    let mut violations: Vec<String> = Vec::new();
+    for file in files {
+        let content = fs::read_to_string(&file).unwrap_or_default();
+        let rel = file
+            .strip_prefix(cg_root())
+            .unwrap_or(&file)
+            .to_string_lossy()
+            .to_string();
+        for f in FORBIDDEN {
+            if content.contains(f) && !is_allowlisted(&rel, f) {
+                violations.push(format!("{}: references `{}`", rel, f));
+            }
+        }
+    }
+    if !violations.is_empty() {
+        panic!(
+            "architectural rule violated for `src/cg/`:\n  {}\n\n\
+             cg/ is the model-agnostic leaf vocabulary; its import set \
+             is closed (std, serde, math2, intra-cg). See \
+             tests/cg_architecture.rs and gridaco/nothing#28.\n\
+             To allow a known temporary violation, add it to ALLOWLIST \
+             with a comment explaining why and when it will be removed.",
+            violations.join("\n  ")
+        );
+    }
+}


### PR DESCRIPTION
First code PR of the **legacy seam program** (#27); implements and closes #28.

## What

`cg/` — the model-agnostic leaf-type vocabulary (paints, colors, strokes, text styles, the SVG IR value types) — had exactly one code-level skia coupling: `impl From<CGPoint> for skia_safe::Point`, with a single call site.

- `shape/polygon.rs` now constructs `skia_safe::Point` directly (shape/ is legitimately skia-coupled; the conversion belongs at that boundary, not on the vocabulary type)
- the `From` impl is deleted — no feature gate, because the future standalone cg crate must not know skia exists
- the one rustdoc path link into `crate::painter` is rewritten as plain text so cg/ docs build without the painter
- **`tests/cg_architecture.rs`** (the `htmlcss_svg_architecture.rs` pattern) makes the closed import set — std / serde / math2 / intra-cg — an executable rule: bans `skia_safe` and every model/runtime module of the crate, with an empty, shrink-only allowlist

Per the program's deciding rule, **extraction is not this PR** — cg/ becomes a crate only when the v2 engine is in-tree as its second consumer.

## Gates

- Behavior-preserving: the replacement is syntactically equivalent codegen (any missed `.into()` site would be a compile error — none were)
- `cargo test -p grida`: 32 suites green (the M0 baseline's 31 + the new architecture suite)
- `cargo clippy -p grida --no-deps`: clean
- M0 baseline (#27) unchanged — no rendering code path touched