### PR TITLE
refactor(import/svg): the IR is the product, pack.rs is the v1 adapter

### DIFF
--- a/crates/grida/src/cg/svg.rs
+++ b/crates/grida/src/cg/svg.rs
@@ -1,7 +1,6 @@
 // Grida's own SVG Types (that with unique properties)
 
 use crate::cg::prelude::*;
-use math2::transform::AffineTransform;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -71,16 +70,6 @@ pub enum SVGGradientSpreadMethod {
     Repeat,
 }
 
-impl From<SVGGradientSpreadMethod> for TileMode {
-    fn from(spread_method: SVGGradientSpreadMethod) -> Self {
-        match spread_method {
-            SVGGradientSpreadMethod::Pad => TileMode::Clamp,
-            SVGGradientSpreadMethod::Reflect => TileMode::Mirror,
-            SVGGradientSpreadMethod::Repeat => TileMode::Repeated,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SVGFillAttributes {
     /// [`fill`] property
@@ -142,158 +131,6 @@ impl Default for SVGStrokeAttributes {
             stroke_opacity: 1.0,
         }
     }
-}
-
-impl SVGFillAttributes {
-    pub fn into_paint_with_opacity(&self, bounds: Option<(f32, f32, f32, f32)>) -> Paint {
-        svg_paint_with_opacity(&self.paint, self.fill_opacity, bounds)
-    }
-}
-
-impl SVGStrokeAttributes {
-    pub fn into_paint_with_opacity(&self, bounds: Option<(f32, f32, f32, f32)>) -> Paint {
-        svg_paint_with_opacity(&self.paint, self.stroke_opacity, bounds)
-    }
-}
-
-/// Helper that converts SVG paint + separate opacity fields into the runtime
-/// `Paint` model (which bakes opacity into each paint entry).
-///
-/// SVG allows opacity on fill/stroke independently of paints; our runtime stores
-/// opacity within each `Paint`. This function is the bridging layer.
-fn svg_paint_with_opacity(
-    paint: &SVGPaint,
-    opacity: f32,
-    bounds: Option<(f32, f32, f32, f32)>,
-) -> Paint {
-    match paint {
-        SVGPaint::Solid(solid) => Paint::Solid(SolidPaint {
-            active: true,
-            color: solid.color.with_multiplier(opacity),
-            blend_mode: BlendMode::Normal,
-        }),
-        SVGPaint::LinearGradient(linear) => svg_linear_gradient_to_paint(linear, opacity, bounds),
-        SVGPaint::RadialGradient(radial) => svg_radial_gradient_to_paint(radial, opacity, bounds),
-    }
-}
-
-fn svg_linear_gradient_to_paint(
-    linear: &SVGLinearGradientPaint,
-    opacity: f32,
-    bounds: Option<(f32, f32, f32, f32)>,
-) -> Paint {
-    let xy1 = Alignment::from_uv(Uv(linear.x1, linear.y1));
-    let xy2 = Alignment::from_uv(Uv(linear.x2, linear.y2));
-    let mut transform = AffineTransform::from(linear.transform);
-    normalize_gradient_transform(&mut transform, bounds);
-
-    Paint::LinearGradient(LinearGradientPaint {
-        active: true,
-        xy1,
-        xy2,
-        tile_mode: linear.spread_method.into(),
-        transform,
-        stops: linear.stops.clone(),
-        opacity,
-        blend_mode: BlendMode::Normal,
-    })
-}
-
-fn svg_radial_gradient_to_paint(
-    radial: &SVGRadialGradientPaint,
-    opacity: f32,
-    bounds: Option<(f32, f32, f32, f32)>,
-) -> Paint {
-    if (radial.fx - radial.cx).abs() > f32::EPSILON || (radial.fy - radial.cy).abs() > f32::EPSILON
-    {
-        return unsupported_svg_gradient("radial focal point (fx/fy)");
-    }
-
-    let mut gradient_transform = AffineTransform::from(radial.transform);
-    normalize_gradient_transform(&mut gradient_transform, bounds);
-    let alignment = radial_gradient_alignment_transform((radial.cx, radial.cy), radial.r);
-
-    Paint::RadialGradient(RadialGradientPaint {
-        active: true,
-        transform: gradient_transform.compose(&alignment),
-        stops: radial.stops.clone(),
-        opacity,
-        blend_mode: BlendMode::Normal,
-        tile_mode: radial.spread_method.into(),
-    })
-}
-
-fn unsupported_svg_gradient(reason: &str) -> Paint {
-    // TODO: Implement support for unsupported SVG gradient features:
-    // - radial gradient focal points (fx/fy different from cx/cy)
-    // For now, we ignore these gradients by returning an inactive paint.
-    let _ = reason;
-    Paint::Solid(SolidPaint {
-        active: false,
-        color: CGColor::TRANSPARENT,
-        blend_mode: BlendMode::Normal,
-    })
-}
-
-fn radial_gradient_alignment_transform(center: (f32, f32), radius: f32) -> AffineTransform {
-    if radius <= f32::EPSILON {
-        return AffineTransform::identity();
-    }
-
-    let translate = translation(center.0, center.1);
-    let scale = scale(radius * 2.0, radius * 2.0);
-    let baseline = translation(-0.5, -0.5);
-
-    translate.compose(&scale).compose(&baseline)
-}
-
-/// Undo the `from_bbox` transform that usvg bakes into gradient transforms
-/// via `to_user_coordinates`.
-///
-/// usvg resolves `objectBoundingBox` gradients by post-concatenating
-/// `from_bbox(rect)` = `[width, 0, x, 0, height, y]` onto the
-/// `gradientTransform`. Our paint model expects the gradient transform
-/// in UV [0,1] space (the painter applies `scale(shape_w, shape_h)`
-/// at render time), so we multiply by `from_bbox_inv` to undo it:
-///
-///   from_bbox_inv = [1/w, 0, -x/w, 0, 1/h, -y/h]
-///
-/// The previous implementation only divided by (w, h), ignoring the
-/// bbox origin (x, y). This caused gradients to be offset when the
-/// shape had a non-zero position.
-fn normalize_gradient_transform(
-    transform: &mut AffineTransform,
-    bounds: Option<(f32, f32, f32, f32)>,
-) {
-    if let Some((x, y, width, height)) = bounds {
-        if width > f32::EPSILON && height > f32::EPSILON {
-            // Apply from_bbox_inv = [1/w, 0, -x/w, 0, 1/h, -y/h]
-            // as a left-multiply: result = from_bbox_inv * transform
-            let inv_w = 1.0 / width;
-            let inv_h = 1.0 / height;
-            let m = &transform.matrix;
-            let new_m00 = inv_w * m[0][0];
-            let new_m01 = inv_w * m[0][1];
-            let new_m02 = inv_w * m[0][2] - x * inv_w;
-            let new_m10 = inv_h * m[1][0];
-            let new_m11 = inv_h * m[1][1];
-            let new_m12 = inv_h * m[1][2] - y * inv_h;
-            transform.matrix[0][0] = new_m00;
-            transform.matrix[0][1] = new_m01;
-            transform.matrix[0][2] = new_m02;
-            transform.matrix[1][0] = new_m10;
-            transform.matrix[1][1] = new_m11;
-            transform.matrix[1][2] = new_m12;
-        }
-    }
-}
-
-fn translation(tx: f32, ty: f32) -> AffineTransform {
-    AffineTransform::from_acebdf(1.0, 0.0, tx, 0.0, 1.0, ty)
-}
-
-fn scale(sx: f32, sy: f32) -> AffineTransform {
-    AffineTransform::from_acebdf(sx, 0.0, 0.0, 0.0, sy, 0.0)
 }
 
 // SVG Packed Scene is dedicated struct for archive / transport format of resolved SVG file.

--- a/crates/grida/src/import/svg/mod.rs
+++ b/crates/grida/src/import/svg/mod.rs
@@ -1,6 +1,14 @@
 //! SVG → Grida import pipeline.
 //!
-//! Produces Grida types (`SceneGraph`, `IRSVG*` IR, `.grida` FBS bytes).
+//! The subsystem's **product is the IR**: [`SVGPackedScene`], built from
+//! usvg by [`packed_scene`]/[`from_usvg`] out of the spec-faithful value
+//! types in [`crate::cg::svg`]. The v1 node model is one *consumer* of
+//! that IR: [`pack`] (scene-graph adapter) and [`grida`] (`.grida` FBS
+//! bytes) are the sink side of the seam, and `paint` is their
+//! IR→runtime-paint projection. Nothing on the IR side may import the
+//! node model — enforced by `tests/svg_import_architecture.rs` (the SVG
+//! sink inversion, gridaco/nothing#29).
+//!
 //! Pure SVG-string transformations (sanitize, optimize, parse) live in
 //! [`crate::formats::svg`].
 

--- a/crates/grida/src/import/svg/mod.rs
+++ b/crates/grida/src/import/svg/mod.rs
@@ -8,5 +8,6 @@ pub mod from_usvg;
 pub mod grida;
 pub mod pack;
 pub mod packed_scene;
+mod paint;
 
 pub use packed_scene::SVGPackedScene;

--- a/crates/grida/src/import/svg/pack.rs
+++ b/crates/grida/src/import/svg/pack.rs
@@ -22,7 +22,18 @@ use math2::transform::AffineTransform;
 
 pub fn from_svg_str(svg: &str) -> Result<SceneGraph, String> {
     let packed = SVGPackedScene::new_from_svg_str(svg)?;
-    SceneBuilder::new().build(packed)
+    scene_graph_from_svg_scene(&packed)
+}
+
+/// v1-model adapter: packs an already-built [`SVGPackedScene`] IR into a
+/// legacy [`SceneGraph`].
+///
+/// This is the sink side of the SVG import seam — the IR is the
+/// subsystem's product; everything v1-specific (root/text container
+/// synthesis, absolute child positioning, stroke-align default, the text
+/// baseline hack) lives on this side of the boundary.
+pub fn scene_graph_from_svg_scene(scene: &SVGPackedScene) -> Result<SceneGraph, String> {
+    SceneBuilder::new().build(scene)
 }
 
 struct SceneBuilder {
@@ -38,7 +49,7 @@ impl SceneBuilder {
         }
     }
 
-    fn build(mut self, scene: SVGPackedScene) -> Result<SceneGraph, String> {
+    fn build(mut self, scene: &SVGPackedScene) -> Result<SceneGraph, String> {
         let mut root = self.factory.create_container_node();
         root.fills = Paints::default();
         root.strokes = Paints::default();

--- a/crates/grida/src/import/svg/pack.rs
+++ b/crates/grida/src/import/svg/pack.rs
@@ -14,6 +14,7 @@ use crate::cg::svg::{
     IRSVGTextNode, SVGFillAttributes, SVGFontStyle, SVGStrokeAttributes,
 };
 use crate::import::svg::packed_scene::SVGPackedScene;
+use crate::import::svg::paint;
 use crate::node::factory::NodeFactory;
 use crate::node::scene_graph::{Parent, SceneGraph};
 use crate::node::schema::*;
@@ -99,13 +100,13 @@ impl SceneBuilder {
         ));
 
         if let Some(fill) = &path.fill {
-            node.fills = Paints::new([fill.into_paint_with_opacity(gradient_bounds)]);
+            node.fills = Paints::new([paint::fill_paint(fill, gradient_bounds)]);
         } else {
             node.fills = Paints::default();
         }
 
         if let Some(stroke) = &path.stroke {
-            node.strokes = Paints::new([stroke.into_paint_with_opacity(gradient_bounds)]);
+            node.strokes = Paints::new([paint::stroke_paint(stroke, gradient_bounds)]);
             node.stroke_style.stroke_cap = stroke.stroke_linecap;
             node.stroke_style.stroke_join = stroke.stroke_linejoin;
             node.stroke_style.stroke_miter_limit = stroke.stroke_miterlimit;
@@ -234,13 +235,13 @@ impl SceneBuilder {
         });
 
         if let Some(fill) = fill {
-            node.fills = Paints::new([fill.into_paint_with_opacity(None)]);
+            node.fills = Paints::new([paint::fill_paint(fill, None)]);
         } else {
             node.fills = Paints::default();
         }
 
         if let Some(stroke) = stroke {
-            node.strokes = Paints::new([stroke.into_paint_with_opacity(None)]);
+            node.strokes = Paints::new([paint::stroke_paint(stroke, None)]);
             node.stroke_width = stroke.stroke_width;
         } else {
             node.strokes = Paints::default();
@@ -298,11 +299,10 @@ impl SceneBuilder {
                     .fill
                     .as_ref()
                     .or(fallback_fill)
-                    .map(|f| vec![f.into_paint_with_opacity(None)]);
+                    .map(|f| vec![paint::fill_paint(f, None)]);
 
                 let stroke_ref = run.stroke.as_ref().or(fallback_stroke);
-                let strokes =
-                    stroke_ref.map(|s| Paints::new(vec![s.into_paint_with_opacity(None)]));
+                let strokes = stroke_ref.map(|s| Paints::new(vec![paint::stroke_paint(s, None)]));
                 let stroke_width = stroke_ref.map(|s| s.stroke_width);
 
                 StyledTextRun {

--- a/crates/grida/src/import/svg/paint.rs
+++ b/crates/grida/src/import/svg/paint.rs
@@ -1,0 +1,180 @@
+//! IRSVG paint attributes → runtime [`Paint`] projection (v1 adapter side).
+//!
+//! The IR types in [`crate::cg::svg`] are spec-faithful SVG values; this
+//! module is the bridge into the runtime paint model: it bakes SVG
+//! fill-/stroke-opacity into each paint entry and normalizes gradient
+//! transforms into the painter's UV `[0,1]` convention. It lives with the
+//! import adapter — not on the IR — so the vocabulary module stays free of
+//! runtime-paint policy (see `tests/svg_import_architecture.rs`).
+//!
+//! Free functions rather than inherent/`From` impls: after the planned
+//! extraction of `cg/` into its own crate, impls over those types from this
+//! crate would violate the orphan rule.
+
+use crate::cg::prelude::*;
+use crate::cg::svg::{
+    SVGFillAttributes, SVGGradientSpreadMethod, SVGLinearGradientPaint, SVGPaint,
+    SVGRadialGradientPaint, SVGStrokeAttributes,
+};
+use math2::transform::AffineTransform;
+
+/// Project an IR fill into a runtime [`Paint`], baking `fill-opacity`.
+pub(crate) fn fill_paint(fill: &SVGFillAttributes, bounds: Option<(f32, f32, f32, f32)>) -> Paint {
+    svg_paint_with_opacity(&fill.paint, fill.fill_opacity, bounds)
+}
+
+/// Project an IR stroke into a runtime [`Paint`], baking `stroke-opacity`.
+pub(crate) fn stroke_paint(
+    stroke: &SVGStrokeAttributes,
+    bounds: Option<(f32, f32, f32, f32)>,
+) -> Paint {
+    svg_paint_with_opacity(&stroke.paint, stroke.stroke_opacity, bounds)
+}
+
+fn tile_mode_from_spread(spread_method: SVGGradientSpreadMethod) -> TileMode {
+    match spread_method {
+        SVGGradientSpreadMethod::Pad => TileMode::Clamp,
+        SVGGradientSpreadMethod::Reflect => TileMode::Mirror,
+        SVGGradientSpreadMethod::Repeat => TileMode::Repeated,
+    }
+}
+
+/// Helper that converts SVG paint + separate opacity fields into the runtime
+/// `Paint` model (which bakes opacity into each paint entry).
+///
+/// SVG allows opacity on fill/stroke independently of paints; our runtime stores
+/// opacity within each `Paint`. This function is the bridging layer.
+fn svg_paint_with_opacity(
+    paint: &SVGPaint,
+    opacity: f32,
+    bounds: Option<(f32, f32, f32, f32)>,
+) -> Paint {
+    match paint {
+        SVGPaint::Solid(solid) => Paint::Solid(SolidPaint {
+            active: true,
+            color: solid.color.with_multiplier(opacity),
+            blend_mode: BlendMode::Normal,
+        }),
+        SVGPaint::LinearGradient(linear) => svg_linear_gradient_to_paint(linear, opacity, bounds),
+        SVGPaint::RadialGradient(radial) => svg_radial_gradient_to_paint(radial, opacity, bounds),
+    }
+}
+
+fn svg_linear_gradient_to_paint(
+    linear: &SVGLinearGradientPaint,
+    opacity: f32,
+    bounds: Option<(f32, f32, f32, f32)>,
+) -> Paint {
+    let xy1 = Alignment::from_uv(Uv(linear.x1, linear.y1));
+    let xy2 = Alignment::from_uv(Uv(linear.x2, linear.y2));
+    let mut transform = AffineTransform::from(linear.transform);
+    normalize_gradient_transform(&mut transform, bounds);
+
+    Paint::LinearGradient(LinearGradientPaint {
+        active: true,
+        xy1,
+        xy2,
+        tile_mode: tile_mode_from_spread(linear.spread_method),
+        transform,
+        stops: linear.stops.clone(),
+        opacity,
+        blend_mode: BlendMode::Normal,
+    })
+}
+
+fn svg_radial_gradient_to_paint(
+    radial: &SVGRadialGradientPaint,
+    opacity: f32,
+    bounds: Option<(f32, f32, f32, f32)>,
+) -> Paint {
+    if (radial.fx - radial.cx).abs() > f32::EPSILON || (radial.fy - radial.cy).abs() > f32::EPSILON
+    {
+        return unsupported_svg_gradient("radial focal point (fx/fy)");
+    }
+
+    let mut gradient_transform = AffineTransform::from(radial.transform);
+    normalize_gradient_transform(&mut gradient_transform, bounds);
+    let alignment = radial_gradient_alignment_transform((radial.cx, radial.cy), radial.r);
+
+    Paint::RadialGradient(RadialGradientPaint {
+        active: true,
+        transform: gradient_transform.compose(&alignment),
+        stops: radial.stops.clone(),
+        opacity,
+        blend_mode: BlendMode::Normal,
+        tile_mode: tile_mode_from_spread(radial.spread_method),
+    })
+}
+
+fn unsupported_svg_gradient(reason: &str) -> Paint {
+    // TODO: Implement support for unsupported SVG gradient features:
+    // - radial gradient focal points (fx/fy different from cx/cy)
+    // For now, we ignore these gradients by returning an inactive paint.
+    let _ = reason;
+    Paint::Solid(SolidPaint {
+        active: false,
+        color: CGColor::TRANSPARENT,
+        blend_mode: BlendMode::Normal,
+    })
+}
+
+fn radial_gradient_alignment_transform(center: (f32, f32), radius: f32) -> AffineTransform {
+    if radius <= f32::EPSILON {
+        return AffineTransform::identity();
+    }
+
+    let translate = translation(center.0, center.1);
+    let scale = scale(radius * 2.0, radius * 2.0);
+    let baseline = translation(-0.5, -0.5);
+
+    translate.compose(&scale).compose(&baseline)
+}
+
+/// Undo the `from_bbox` transform that usvg bakes into gradient transforms
+/// via `to_user_coordinates`.
+///
+/// usvg resolves `objectBoundingBox` gradients by post-concatenating
+/// `from_bbox(rect)` = `[width, 0, x, 0, height, y]` onto the
+/// `gradientTransform`. Our paint model expects the gradient transform
+/// in UV [0,1] space (the painter applies `scale(shape_w, shape_h)`
+/// at render time), so we multiply by `from_bbox_inv` to undo it:
+///
+///   from_bbox_inv = [1/w, 0, -x/w, 0, 1/h, -y/h]
+///
+/// The previous implementation only divided by (w, h), ignoring the
+/// bbox origin (x, y). This caused gradients to be offset when the
+/// shape had a non-zero position.
+fn normalize_gradient_transform(
+    transform: &mut AffineTransform,
+    bounds: Option<(f32, f32, f32, f32)>,
+) {
+    if let Some((x, y, width, height)) = bounds {
+        if width > f32::EPSILON && height > f32::EPSILON {
+            // Apply from_bbox_inv = [1/w, 0, -x/w, 0, 1/h, -y/h]
+            // as a left-multiply: result = from_bbox_inv * transform
+            let inv_w = 1.0 / width;
+            let inv_h = 1.0 / height;
+            let m = &transform.matrix;
+            let new_m00 = inv_w * m[0][0];
+            let new_m01 = inv_w * m[0][1];
+            let new_m02 = inv_w * m[0][2] - x * inv_w;
+            let new_m10 = inv_h * m[1][0];
+            let new_m11 = inv_h * m[1][1];
+            let new_m12 = inv_h * m[1][2] - y * inv_h;
+            transform.matrix[0][0] = new_m00;
+            transform.matrix[0][1] = new_m01;
+            transform.matrix[0][2] = new_m02;
+            transform.matrix[1][0] = new_m10;
+            transform.matrix[1][1] = new_m11;
+            transform.matrix[1][2] = new_m12;
+        }
+    }
+}
+
+fn translation(tx: f32, ty: f32) -> AffineTransform {
+    AffineTransform::from_acebdf(1.0, 0.0, tx, 0.0, 1.0, ty)
+}
+
+fn scale(sx: f32, sy: f32) -> AffineTransform {
+    AffineTransform::from_acebdf(sx, 0.0, 0.0, 0.0, sy, 0.0)
+}

--- a/crates/grida/tests/svg_import_architecture.rs
+++ b/crates/grida/tests/svg_import_architecture.rs
@@ -1,0 +1,165 @@
+//! Architectural tests for the SVG import seam.
+//!
+//! The SVG import subsystem's product is the `IRSVG` tree
+//! (`SVGPackedScene`); the v1 node model is one *consumer* of that IR
+//! through the adapter (`import/svg/pack.rs` + `grida.rs`). These tests
+//! enforce the seam (the SVG sink inversion, gridaco/nothing#29, under
+//! the legacy seam program gridaco/nothing#27):
+//!
+//! - **The IR layer must not know the node model.** `cg/svg.rs`,
+//!   `import/svg/packed_scene.rs`, `import/svg/from_usvg.rs`, and
+//!   everything under `formats/svg/` may not reference `node::schema`,
+//!   the factory, or the scene graph.
+//! - **The IR must not carry runtime-paint policy.** The
+//!   SVG→runtime-`Paint` projection (baked opacity, UV-space gradient
+//!   normalization) lives in `import/svg/paint.rs` on the adapter side;
+//!   `cg/svg.rs` stays spec-faithful vocabulary.
+//! - **Only the adapter touches the model.** Within `import/svg/`, only
+//!   `pack.rs` and `grida.rs` may reference `crate::node`.
+//!
+//! When this test fails, do not loosen the rule. Either move the
+//! offending code to the right side of the seam, or restructure the
+//! import so the type doesn't cross the boundary.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Tokens that mean "this file knows the v1 node model".
+const MODEL_TOKENS: &[&str] = &[
+    "node::schema",
+    "crate::node",
+    "NodeFactory",
+    "SceneGraph",
+    "scene_graph",
+];
+
+/// Tokens that mean "this file projects into the runtime paint model".
+/// Banned in `cg/svg.rs` so the IR vocabulary stays spec-faithful.
+/// Checked after stripping the legitimate `SVG*`-prefixed IR type names,
+/// so `SVGSolidPaint`/`SVGPaint::` don't false-positive.
+const PAINT_PROJECTION_TOKENS: &[&str] = &[
+    "into_paint",
+    "SolidPaint",
+    "LinearGradientPaint",
+    "RadialGradientPaint",
+    "Paint::",
+];
+
+/// The IR's own spec-faithful type names, removed from the text before
+/// scanning for the runtime-paint tokens above. Longest first.
+const IR_TYPE_NAMES: &[&str] = &[
+    "SVGLinearGradientPaint",
+    "SVGRadialGradientPaint",
+    "SVGSolidPaint",
+    "SVGPaint",
+];
+
+/// Known follow-ups; keep this list **shrinking, not growing**.
+const ALLOWLIST: &[(&str, &str)] = &[];
+
+fn crate_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn rs_files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for ent in entries.flatten() {
+        let p = ent.path();
+        if p.is_dir() {
+            out.extend(rs_files_under(&p));
+        } else if p.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+    out
+}
+
+fn is_allowlisted(file_rel: &str, forbidden: &str) -> bool {
+    ALLOWLIST
+        .iter()
+        .any(|&(f, n)| file_rel.ends_with(f) && n == forbidden)
+}
+
+fn check_files(files: &[PathBuf], forbidden: &[&str], rule: &str) {
+    let root = crate_root();
+    let mut violations: Vec<String> = Vec::new();
+    for file in files {
+        let content = fs::read_to_string(file).unwrap_or_default();
+        let rel = file
+            .strip_prefix(&root)
+            .unwrap_or(file)
+            .to_string_lossy()
+            .to_string();
+        for f in forbidden {
+            if content.contains(f) && !is_allowlisted(&rel, f) {
+                violations.push(format!("{rel}: references `{f}`"));
+            }
+        }
+    }
+    if !violations.is_empty() {
+        panic!(
+            "SVG import seam violated ({rule}):\n  {}\n\n\
+             See tests/svg_import_architecture.rs and gridaco/nothing#29.\n\
+             To allow a known temporary violation, add it to ALLOWLIST \
+             with a comment explaining why and when it will be removed.",
+            violations.join("\n  ")
+        );
+    }
+}
+
+#[test]
+fn ir_layer_does_not_know_the_node_model() {
+    let root = crate_root();
+    let mut files = vec![
+        root.join("src/cg/svg.rs"),
+        root.join("src/import/svg/packed_scene.rs"),
+        root.join("src/import/svg/from_usvg.rs"),
+    ];
+    files.extend(rs_files_under(&root.join("src/formats/svg")));
+    assert!(files.iter().all(|f| f.exists()), "IR layer files moved?");
+    check_files(&files, MODEL_TOKENS, "IR layer must not import the model");
+}
+
+#[test]
+fn ir_vocabulary_carries_no_paint_projection() {
+    let path = crate_root().join("src/cg/svg.rs");
+    let mut content = fs::read_to_string(&path).expect("cg/svg.rs moved?");
+    for name in IR_TYPE_NAMES {
+        content = content.replace(name, "");
+    }
+    let violations: Vec<String> = PAINT_PROJECTION_TOKENS
+        .iter()
+        .filter(|t| content.contains(**t))
+        .map(|t| format!("src/cg/svg.rs: references `{t}`"))
+        .collect();
+    if !violations.is_empty() {
+        panic!(
+            "SVG import seam violated (cg/svg.rs is spec-faithful vocabulary; \
+             the projection lives in import/svg/paint.rs):\n  {}\n\n\
+             See tests/svg_import_architecture.rs and gridaco/nothing#29.",
+            violations.join("\n  ")
+        );
+    }
+}
+
+#[test]
+fn only_the_adapter_touches_the_model() {
+    let root = crate_root();
+    let svg_dir = root.join("src/import/svg");
+    let files: Vec<PathBuf> = rs_files_under(&svg_dir)
+        .into_iter()
+        .filter(|p| {
+            let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            name != "pack.rs" && name != "grida.rs"
+        })
+        .collect();
+    assert!(!files.is_empty(), "no non-adapter files under import/svg?");
+    check_files(
+        &files,
+        &["crate::node"],
+        "only pack.rs and grida.rs may consume the node model",
+    );
+}


### PR DESCRIPTION
Second seam of the **legacy seam program** (#27); implements and closes #29. Two commits with distinct jobs:

## Commit 1 — move the runtime-Paint projection off the IR

The `IRSVG` types in `cg/svg.rs` carried the SVG→runtime-`Paint` projection (`into_paint_with_opacity` + gradient helpers) as inherent impls. That projection encodes **painter conventions** — baked fill/stroke opacity, gradient transforms normalized into the painter's UV `[0,1]` space, the radial focal-point drop — i.e. adapter policy, not SVG-spec semantics.

It moves **verbatim** to `import/svg/paint.rs` as free functions (`fill_paint`/`stroke_paint` + private helpers; free functions because impls over cg types from this crate would violate the orphan rule after the planned cg extraction). The `From<SVGGradientSpreadMethod> for TileMode` impl becomes the private `tile_mode_from_spread` — the Pad/Reflect/Repeat interpretation is the painter's, so it moves with the projection. `cg/svg.rs` is now vocabulary-only: zero runtime `Paint` references.

## Commit 2 — the adapter inversion + the lock

`scene_graph_from_svg_scene(&SVGPackedScene) -> Result<SceneGraph, String>` is the named v1 adapter entry; `from_svg_str` keeps its signature (parse-then-adapt — the wasm surface's `svg_to_grida_bytes` is untouched). Everything v1-specific (root/text container synthesis, absolute child positioning, stroke-align default, the baseline hack) stays on the adapter side.

**`tests/svg_import_architecture.rs`** locks the seam three ways: the IR layer (`cg/svg.rs`, `packed_scene.rs`, `from_usvg.rs`, `formats/svg/**`) must not reference the node model; `cg/svg.rs` must carry no runtime-paint projection (scanned after stripping the legitimate `SVG*`-prefixed IR type names); only `pack.rs` + `grida.rs` may touch `crate::node`.

## Gates (all green)

- `tests/svg_pack.rs` — **unmodified** (git diff empty on it), all 48 tests green; its 1761 lines of behavior-precise transform/gradient/text assertions are the spec
- Full `cargo test -p grida`: 32 suites ok
- `cargo run --example golden_svg_gradients`: green
- **iosvg reftest, full `resvg-test-suite` (1679 fixtures): every rendered PNG byte-identical to the M0 baseline** (#27 baseline comment); bucket scores identical (avg 71.45%, consensus 703/1425 @ 0.95). Renderer pinned to `iosvg` — the `reftest-run.sh` default (`htmlcss`) bypasses `pack.rs` entirely and would gate nothing.

Known IR completeness gaps (images, clip-paths, masks, filters, patterns, per-stop opacity, radial focal point) are deliberately untouched — the seam must not hide them; they remain catalogued in #29.