### PR TITLE
docs(wg): the paint-model RFD + the display-list contract study

### DIFF
--- a/docs/wg/feat-2d/display-list-contract.md
+++ b/docs/wg/feat-2d/display-list-contract.md
@@ -1,0 +1,176 @@
+---
+title: Display-List Contract Study
+description: "Design study: whether a shared display-list contract between the two engines should exist. Conclusion: no — the shared surface stops at the leaf paint vocabulary."
+tags:
+  - internal
+  - wg
+  - canvas
+  - rendering
+format: md
+---
+
+# Display-List Contract Study
+
+**Status:** Design study — findings, not a spec. This document answers
+one question and does not define a contract.
+
+Written for an engine developer deciding, at promotion time, whether
+the two engines' display lists need a shared specification. Filed from
+[gridaco/nothing#33](https://github.com/gridaco/nothing/issues/33) under
+the seam program
+[gridaco/nothing#27](https://github.com/gridaco/nothing/issues/27),
+which states the lean this study tests: *the shared surface stops at
+the leaf vocabulary; the display list is per-engine.*
+
+## The question
+
+Both engines compile the same scene vocabulary — nodes carrying ordered
+paint stacks and stroke applications, per the
+[Paint Model RFD](../feat-painting/paint-model.md) — into an
+intermediate form their renderer executes: a display list. Must that
+intermediate form be specified once, as a contract both engines
+conform to? Or is it engine-internal?
+
+## The two projections
+
+The evidence is the two display lists as they exist. Described in
+domain terms:
+
+**The production engine's projection** is a *retained layer tree*. Each
+leaf is a self-contained layer of pure draw content — resolved shape,
+fill stack, stroke stack, effects — deliberately excluding transform,
+opacity, blend, and clip so the recorded content can be cached and
+replayed across frames under changing composite state. That composite
+state (opacity, blend mode, world transform, clip path, z-index) lives
+in a base record *on every layer*. Above the leaves sits a command
+tree: draw commands, mask groups pairing mask-command lists with
+content-command lists, and effect surfaces — interior nodes that
+composite their children offscreen and apply container-level effects
+once to the composited result. The design optimizes for **picture
+caching and partial invalidation**: a layer records once and redraws
+cheaply; a geometry-only change patches one base record in place.
+
+**The v2 proof's projection** is a *flat ordered stream* of items. Each
+item pairs one node's leaf primitive — a fill or one stroke application
+over a rect, oval, path, line, or resolved text layout — with a world
+transform copied verbatim from the resolver, never recomputed. Scoped
+state is expressed not as node attributes but as *paired bracket
+commands in the stream*: an opacity group opens and closes around a
+range of items; a content clip opens after a container's fill and
+closes before its own strokes. There are no mask or effect constructs.
+The design optimizes for **purity and diffability**: the stream is a
+value, comparable by equality between frames, with no camera baked in
+so one list paints at any zoom.
+
+### The structural inversion
+
+The two encode the same information in inverse positions:
+
+| Dimension                              | Production projection                                            | v2 projection                                                    |
+| -------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Overall shape                          | Tree of commands over retained layers                            | Flat ordered stream of items                                     |
+| Composite state (opacity, blend, clip) | Attribute of each layer's base record                            | Paired begin/end bracket commands scoping a range                |
+| World transform                        | Stored per layer, patchable in place                             | Copied per item from the resolver, verbatim                      |
+| Grouping constructs                    | Mask groups and effect surfaces as interior tree nodes           | Opacity and clip brackets; no mask or effect construct           |
+| Optimized for                          | Picture caching, partial invalidation, per-layer reuse           | Value equality, frame diffing, camera-free replay                |
+| Leaf content                           | Shape + fill stack + stroke stack + effects, in one layer        | One primitive per item: a fill *or* one stroke application       |
+
+Attribute-of-node versus bracket-in-stream is not a stylistic
+difference. Flattening the tree into a bracketed stream is mechanical;
+reconstructing the tree from the stream means re-inferring grouping —
+which is exactly each engine's own compile policy. A shared contract
+would have to legislate one of the two encodings, and the engine on the
+losing side would rebuild its renderer around the other's structure.
+
+### The capability asymmetry
+
+The two lists also do not cover the same feature set. Masks, effect
+surfaces, and z-ordering exist only in the production projection;
+value-view projection and the pinned text-font registry accompanying
+glyph-bearing items exist only in the v2 projection. A shared contract
+must be the union of both vocabularies — so each engine would carry
+constructs it never produces and cannot execute, or the contract
+fragments into profiles, which is the absence of a contract wearing its
+costume.
+
+### What is actually shared
+
+Every leaf of both projections pairs a geometry with values from the
+same paint vocabulary: an ordered paint stack for fills, a stroke
+application for strokes, and — for text — a resolved layout with the
+tri-state run-paint ownership of the paint model. The sharing the seam
+program needs already exists **one level below the display list**, and
+it is specified: the [Paint Model RFD](../feat-painting/paint-model.md)
+for the values, and the
+[Universal Shaped Text Layout RFD](../feat-paragraph/text-layout.md)
+for the resolved text artifact those leaves consume.
+
+### The consumer test
+
+The seam program's standing rule is that a boundary earns a contract
+when its second consumer appears — and not before. Applied here: each
+display list has exactly one producer (its engine's compiler) and
+exactly one consumer (the same engine's executor), living in the same
+codebase and shipping on the same commit. No serialized display list
+crosses a process, wire, or version boundary. There is no foreign
+consumer to protect, so a contract would protect no one — while still
+charging both engines its full conformance cost.
+
+## Conclusion
+
+**The lean is confirmed. No shared display-list contract should exist,
+and no display-list spec should be authored.**
+
+- The shared surface between the two engines stops at the leaf
+  vocabulary — the paint model and the resolved-text artifact. That
+  surface is already specified in its own homes.
+- The display list is each engine's private projection of that
+  vocabulary, shaped by the performance strategy it serves — retained
+  caching in one, pure diffable streams in the other. The two
+  structures are inverses; a shared contract would rewrite one engine
+  in the other's image and freeze both engines' performance strategies
+  into a document neither would honor for long.
+- A WG contract binds inputs (the scene and paint vocabulary) and
+  outputs (pixels, under conformance suites) — not the intermediate a
+  renderer chooses on the way from one to the other.
+
+### Conditions that reopen this question
+
+The conclusion is falsifiable. Any one of these creates the foreign
+boundary that would demand a spec, scoped to what the new consumer
+actually needs:
+
+1. **A display list crosses a process or wire boundary** — a remote
+   renderer, a replay file format, or display-list interchange between
+   engines.
+2. **A second in-repo consumer of a display list appears** — for
+   example an exporter or hit-tester consuming the compiled list
+   instead of the scene.
+3. **Leaf-vocabulary divergence** — if the engines stop agreeing on the
+   leaf pairing of geometry with paint-model values, the shared surface
+   has moved and its boundary must be re-drawn.
+
+If reopened, the spec's scope is the *serialized leaf stream and its
+scoping brackets* for the crossing in question — not a unification of
+the two engines' internal structures, which this study found to be the
+expensive non-goal.
+
+## Evidence
+
+Non-normative provenance — where the two projections were read. The
+production engine is cited by path in this repository; the v2 proof by
+branch and path in prose.[^branch-links]
+
+- Production engine (`main`): the retained layer tree, per-layer base
+  record, mask groups, and effect surfaces in
+  [`crates/grida/src/painter/layer.rs`](../../../crates/grida/src/painter/layer.rs).
+- v2 proof (branch `model-v2-anchor`, locked as a design reference; see
+  [gridaco/nothing#9](https://github.com/gridaco/nothing/issues/9)):
+  the flat item stream, paired scope commands, and per-item world
+  transforms in `model-v2/engine/src/drawlist.rs`.
+
+[^branch-links]: This repo's link discipline permits only `main`-target
+    repository links — no branch or commit pins — so v2 evidence on the
+    locked `model-v2-anchor` branch is cited by branch name and path in
+    prose rather than hyperlinked. The branch is reachable from the
+    tracking issue above.

--- a/docs/wg/feat-painting/paint-model.md
+++ b/docs/wg/feat-painting/paint-model.md
@@ -1,0 +1,531 @@
+---
+title: The Paint Model
+description: "Open RFD for the shared paint vocabulary — color, stroke, ordered paints, the text-style partition, and canonical gradient/image field sets — that both engines adopt at promotion."
+tags:
+  - internal
+  - wg
+  - canvas
+  - painting
+  - rendering
+format: md
+---
+
+# The Paint Model
+
+**Status:** Open RFD.
+
+This document is written for an engine developer deciding, at promotion
+time, what the shared paint vocabulary is — the leaf-level value types
+that a scene hands to a renderer. Two engines exist today: the production
+engine and the v2 proof. Their paint vocabularies have the identical
+variant set — solid, linear gradient, radial gradient, sweep gradient,
+diamond gradient, image — but differ in representation at five points.
+This RFD argues each of the five to a recommendation. It settles
+vocabulary, not code: both implementations are cited as evidence only,
+never as the norm. Ratification happens on the originating issue
+([gridaco/nothing#33](https://github.com/gridaco/nothing/issues/33),
+under the seam program
+[gridaco/nothing#27](https://github.com/gridaco/nothing/issues/27)); the
+authored-contract constraints it inherits are locked by
+[gridaco/nothing#9](https://github.com/gridaco/nothing/issues/9).
+
+The companion study
+[Display-List Contract Study](../feat-2d/display-list-contract.md)
+concludes that the shared surface between the two engines stops at this
+leaf vocabulary — the display list each engine compiles it into is
+per-engine and deliberately unspecified. This RFD is therefore the whole
+shared surface.
+
+## Scope
+
+In scope: the value vocabulary of painting — color, the paint variants,
+the ordered paint stack, the stroke application, gradient and image
+field sets, and the paint-only half of text style.
+
+Out of scope, each with its owning home:
+
+- **Compositing of node opacity against fill and stroke** — owned by
+  [Stroke-Fill Opacity Compositing](../feat-2d/stroke-fill-opacity.md).
+- **Layout-affecting text style** — owned by the
+  [Universal Shaped Text Layout RFD](../feat-paragraph/text-layout.md)
+  (decision 4 below states the boundary).
+- **Per-side rectangular stroke geometry** — owned by
+  [Rectangular Stroke Model](./stroke-rect.md).
+- **Endpoint markers and curve decoration** — owned by
+  [Curve Decoration](../feat-2d/curve-decoration.md).
+- **Node-level blend and isolation** — compositing model, not paint
+  vocabulary; see [Isolation Mode](../feat-2d/isolation-mode.md) and the
+  stroke-fill opacity spec above.
+- **Wide-gamut color management** — named as the successor to decision 1,
+  deferred with its blocker stated there.
+
+## Vocabulary
+
+| Term                   | Meaning                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Paint**              | A self-contained recipe for producing color over a region: one of solid, linear, radial, sweep, diamond gradient, or image.          |
+| **Paint stack**        | An ordered, finite list of paints composited in sequence; entry zero is bottommost.                                                  |
+| **Stroke application** | One stroke geometry — width, align, cap, join, miter limit, dash pattern — carrying its own paint stack. Repeatable per node.        |
+| **Unit gradient space**| The `[0,1] × [0,1]` box in which radial, sweep, and diamond gradients are defined, with implicit center `(0.5, 0.5)`.               |
+| **Alignment point**    | A point in center-based normalized coordinates over the paint target box: `(-1,-1)` top-left, `(0,0)` center, `(1,1)` bottom-right. |
+| **Stop**               | A pair of a scalar offset in `[0,1]` and a color.                                                                                    |
+| **Quantization policy**| The declared rule a boundary applies when converting a unit-interval scalar channel to an 8-bit channel.                             |
+| **Paint-only value**   | A value whose change cannot alter resolved geometry — only which ink fills already-resolved geometry.                                |
+
+---
+
+## Decision 1 — Color representation
+
+### The question
+
+Is the canonical color a packed 32-bit word, a struct of four 8-bit
+channels, or four float channels with a color-space tag? And what are
+the conversion laws between the forms that exist at the boundaries?
+
+### Evidence
+
+Three representations are in production use today:
+
+1. The archive format stores color as **four 32-bit floats** in `[0,1]`
+   (annotated in the schema as linear space).
+2. The production engine's runtime value is a **struct of four 8-bit
+   channels** (r, g, b, a), constructed from packed words in *both*
+   `RRGGBBAA` and `AARRGGBB` orders depending on the constructor used.
+3. The v2 proof's value is a **packed 32-bit word** in `AARRGGBB` order,
+   with hex strings treated strictly as parse inputs and serialize
+   outputs — never stored.
+
+Two facts anchor the analysis:
+
+- The archive decode boundary converts float channels to bytes by
+  **round-to-nearest**; the HTML import boundary converts by
+  **truncation**. The same authored channel value can therefore arrive
+  in the engine as two different bytes depending on which door it came
+  through — off by one, which is enough to break value equality, cache
+  keys, and cross-engine pixel identity.
+- Both runtimes agree that a **solid paint's opacity is its color's
+  alpha channel** — deliberately not a second scalar field. Alpha is
+  part of the color value, stored straight (unpremultiplied).
+
+### Deciding table
+
+| Candidate                          | Equality & hashing                        | Interchange form                    | Wide-gamut headroom | Where quantization lives                              |
+| ---------------------------------- | ----------------------------------------- | ----------------------------------- | ------------------- | ----------------------------------------------------- |
+| Packed 32-bit RGBA8 word           | Bitwise; one integer compare              | One number, one declared byte order | None                | Confined to authoring/import boundaries               |
+| Four-byte channel struct           | Field-wise, equal to bitwise              | Four named fields                   | None                | Confined to authoring/import boundaries               |
+| Four floats + color-space tag      | Epsilon or bit-pattern; NaN is a hazard   | Four floats plus a tag              | Yes                 | Moves inside the engine, paid at raster time          |
+
+The first two rows are informationally identical: the packed word and
+the channel struct are related by a bijection (byte placement, no
+arithmetic), so choosing between them is not a semantic decision — it is
+a choice of canonical identity and interchange form. The real semantic
+decision is 8-bit quantized channels versus float channels, and on that
+both engines already agree: the working value is RGBA8. The float form
+appears only at the archive boundary, as an encoding of an RGBA8 value —
+values off the 1/255 grid are not losslessly authorable today, so the
+float spelling grants no extra gamut in practice.
+
+### Recommendation
+
+1. **The canonical color value is one RGBA8 quadruple with straight
+   (unpremultiplied) alpha.** A solid paint's opacity *is* its alpha;
+   no second opacity field exists on solid paints.
+2. **The canonical identity and interchange form is the packed 32-bit
+   word, in exactly one declared byte order.** Channel access is a
+   projection of the word, not a second storage form. The vocabulary
+   must name the order explicitly (most-significant byte first:
+   `A, R, G, B` is the order the current packed implementation uses);
+   the evidence shows two packed orders coexisting behind constructor
+   names today, which is precisely the ambiguity a single declared
+   order removes.
+3. **The lossless conversion laws.**
+   - *Word ↔ channel struct*: bijective byte placement; lossless in
+     both directions.
+   - *Byte → unit float*: `f = n / 255`; every byte value is exactly
+     representable; lossless.
+   - *Unit float → byte*: `n = round(clamp(f, 0, 1) × 255)`,
+     round-to-nearest. Under this rule the byte → float → byte round
+     trip is the identity. Any float off the 1/255 grid loses
+     information — that loss is **quantization, and quantization is
+     caller policy**: it is a property of the converting boundary, not
+     of the color type, because the value carries no memory of how it
+     was produced. Every boundary that accepts arbitrary floats must
+     declare its rule. The vocabulary makes round-to-nearest the
+     conformance default; the observed truncating boundary is, under
+     this RFD, a deviation to be corrected at promotion.
+4. **The transfer characteristic must be declared, and today it is
+   contradicted.** The archive annotates its float channels as linear;
+   both runtimes hand the same 8-bit channels to the rasterizer without
+   a conversion step, which treats them as display-encoded. Both
+   statements cannot be true. This RFD does not resolve color
+   management; it flags the contradiction as a must-resolve conformance
+   clause and defers the wide-gamut canonical form (float channels plus
+   a color-space tag — the successor row of the table) to a dedicated
+   color-management effort, which is its named blocker.
+
+---
+
+## Decision 2 — The stroke model
+
+### The question
+
+Is a stroke a *geometry carrying ordered paints*, or a *paint carrying
+stroke parameters*?
+
+### Constraint inherited
+
+[gridaco/nothing#9](https://github.com/gridaco/nothing/issues/9) locks
+the authored contract: `stroke` is **repeatable**; each occurrence is an
+independent geometry with its own ordered paint stack. Repeated strokes
+paint in source order after the node's children; within one stroke the
+paints composite bottom-to-top. The vocabulary must be able to express
+what the format promises.
+
+### Evidence
+
+- The production engine's node records carry **one** stroke geometry —
+  width, align, cap, join, miter limit, dash pattern, flattened onto the
+  node — plus one ordered paint stack for strokes. Two strokes of
+  different widths on one node are not expressible.
+- The v2 proof carries a unified **stroke application**: a value
+  bundling the six geometry properties with its own paint stack, held
+  as a repeatable list per node. It is the element type of the
+  repeatable authored `stroke`.
+- Both sides use the *same* paint type for fills and for stroke paints;
+  no paint variant carries stroke parameters anywhere in either engine.
+
+### Deciding table
+
+| Question                                                    | A — geometry carries ordered paints           | B — paint carries stroke parameters                                  | C — node carries one geometry + one stack (status quo)   |
+| ----------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
+| Expresses the authored repeatable-stroke contract           | Yes, structurally — one value per occurrence  | Only by repeating identical geometry on every paint; the grouping invariant is conventional, not structural | No — a single geometry cannot carry two widths           |
+| Paint type stays reusable between fill and stroke           | Yes — paints stay geometry-free               | No — stroke fields are dead knobs in fill position                    | Yes                                                      |
+| Multiple paints under one geometry                          | The paint stack, verbatim                     | Geometry duplicated per paint; equality of geometry becomes accidental | The paint stack, verbatim                                |
+| Legacy corpus maps losslessly                               | Yes — as exactly one stroke application       | Yes, with n-fold geometry duplication                                 | Identity                                                 |
+
+### Recommendation
+
+**A.** The stroke is a geometry that carries an ordered paint stack —
+the *stroke application* of the vocabulary table. Paints stay
+geometry-free and identical between fill and stroke positions.
+
+The stroke application's field set:
+
+| Field        | Type                                                          | Notes                                                                                                     |
+| ------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| paints       | Paint stack                                                   | Ordered; decision 3 semantics                                                                             |
+| width        | One of: none · uniform scalar · per-side rectangular widths   | The rectangular form is valid only for rectangular outlines; geometry owned by [stroke-rect](./stroke-rect.md) |
+| align        | inside · center · outside                                     | Identical three-value enum on both sides                                                                   |
+| cap          | butt · round · square                                         | Open paths only                                                                                            |
+| join         | miter · round · bevel                                         |                                                                                                            |
+| miter limit  | Scalar, default 4.0                                           | The cross-standard default (SVG, Canvas, PDF, and the raster backends)                                     |
+| dash pattern | Optional list of scalars                                      | Dash phase is a tracked, currently-absent capability ([gridaco/nothing#15](https://github.com/gridaco/nothing/issues/15)) |
+
+**Ordering laws.** Stroke applications paint in list order. Within one
+application, paints composite bottom-to-top per decision 3. Strokes
+paint after the node's children (the authored contract of
+gridaco/nothing#9).
+
+**Promotion law.** A legacy node record — one flattened stroke geometry
+plus one stroke paint stack — maps to a list of exactly one stroke
+application. The mapping is lossless and mechanical; no legacy document
+can express anything the new form cannot.
+
+**Named deferrals.** Variable-width stroke profiles (vector-network
+strokes) and endpoint markers are node-capability extensions outside
+this vocabulary; markers are owned by
+[Curve Decoration](../feat-2d/curve-decoration.md).
+
+---
+
+## Decision 3 — Ordered paint-stack semantics
+
+### The question
+
+What exactly does an ordered paint stack mean? The production engine's
+semantics are declared the source of truth by
+[gridaco/nothing#9](https://github.com/gridaco/nothing/issues/9); this
+decision pins them in domain terms so a second implementer needs no
+source access.
+
+### The laws
+
+1. **Order.** A paint stack is an ordered finite list. Entry zero is
+   painted first and is therefore bottommost; each later entry
+   composites over the accumulated result of the entries before it.
+   Stored order is canonical engine order. A user interface may
+   *display* the list top-first; that is presentation, never storage.
+2. **Per-paint state.** Every paint carries: an active flag, an opacity
+   in `[0,1]` (for solid paints, the color's alpha — decision 1), and a
+   blend mode.
+3. **Visibility.** A paint is visible iff it is active and its opacity
+   is greater than zero. An invisible paint contributes no pixels
+   regardless of blend mode and may be removed from a stack without any
+   pixel change. Filtering invisible paints preserves the relative
+   order of the survivors.
+4. **Blend locality.** A paint's blend mode applies when that paint is
+   composited over the accumulated result of the *earlier entries of the
+   same stack*. It never retroactively affects paints already drawn,
+   and it does not blend against content outside the stack's own
+   compositing context.
+5. **Node opacity is not distributive.** Node-level opacity is group
+   isolation — the node's fill, strokes, and effects are composited at
+   full opacity into an isolated group which is then composited at the
+   node's opacity. Folding node opacity into per-paint alpha is an
+   optimization with validity conditions, and both the model and those
+   conditions are owned by
+   [Stroke-Fill Opacity Compositing](../feat-2d/stroke-fill-opacity.md);
+   this spec only pins that the paint stack itself carries no node
+   opacity.
+6. **Empty is not absent.** An empty stack means *explicitly no ink*.
+   In inheriting contexts (per-run text fills, decision 4) the absent
+   stack means *inherit*, and the two states are distinct and must not
+   collapse into each other.
+
+### Deciding table
+
+The one representational choice inside these laws is the canonical
+order:
+
+| Question                                                      | First-is-bottommost (recommended)     | First-is-topmost                                            |
+| ------------------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------- |
+| Matches paint execution (draw order = list order)             | Yes — index equals draw sequence      | No — renderer iterates in reverse                           |
+| Matches both engines' storage today                           | Yes                                   | No                                                          |
+| Matches the authored fill channel of gridaco/nothing#9        | Yes — first child is bottommost       | No                                                          |
+| Matches common editor list displays                           | No — UIs show topmost first           | Yes                                                         |
+
+### Recommendation
+
+Pin the laws above verbatim, with first-is-bottommost canonical order.
+The editor-display mismatch is a view concern; storing display order
+would make every renderer and every conversion layer pay a reversal to
+serve one presentation.
+
+---
+
+## Decision 4 — The text-style partition
+
+### The question
+
+Text style contains both values that change geometry (font, size,
+spacing) and values that only change ink (fill paints, decoration
+color). Which half does this spec own?
+
+### Constraint inherited
+
+The [Universal Shaped Text Layout RFD](../feat-paragraph/text-layout.md)
+owns text resolution. Its contract already draws the line this decision
+needs: layout-affecting style participates in the resolution inputs and
+the artifact's cache identity; *paint-only values may remain associated
+with source ranges but do not change shaping or invalidate layout*.
+Nothing may be decided twice, so this spec must not restate any of that
+— it may only own what falls on the paint side of the line the
+text-layout RFD draws.
+
+### Deciding table
+
+| Option                                                             | One concept, one home                                        | Invalidation semantics                                                       | Duplication risk                                        |
+| ------------------------------------------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------- |
+| This spec owns all of text style                                   | Violated — shaping inputs specified outside the text contract | Paint spec would have to restate layout invalidation rules                    | High — two homes for font selection                     |
+| The text-layout RFD owns all of text style, including paints       | Violated — a second paint model appears inside text           | Correct for layout, but paint changes would key layout caches unnecessarily   | High — a text-specific paint vocabulary emerges (an explicit non-goal of that RFD) |
+| Partition: layout-affecting half there, paint-only half here       | Both homes honest                                            | Layout caches key on layout inputs; painted output keys on paint state separately | None — the boundary is one sentence                     |
+
+### Recommendation
+
+**Partition.** The boundary rule: *a text-style value is
+layout-affecting iff changing it can alter the resolved text layout's
+geometry; every layout-affecting value belongs to the text-layout RFD;
+this spec owns only paint-only values.* Applied to the known property
+classes:
+
+| Property class                                                                     | Owner                                                              |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Font selection: family, weight, width, posture, optical sizing, features, variable axes | Text-layout RFD                                              |
+| Size, letter spacing, word spacing, line height, text transform, kerning           | Text-layout RFD                                                    |
+| Decoration geometry: which line, thickness, style                                  | Text-layout RFD (layout-owned decoration ink)                      |
+| Decoration color                                                                   | **This spec** — paint-only; defaults to the run's effective text color |
+| Per-run fill stacks and their inheritance                                          | **This spec** (below)                                              |
+| Text strokes                                                                       | **This spec** — text strokes are stroke applications (decision 2)  |
+
+The paint-only vocabulary this spec owns is small:
+
+1. **Run fill ownership.** A text node carries a node-level fill stack.
+   Each styled run may carry an *optional* fill-stack override with
+   tri-state semantics: absent means inherit the node's fills; present
+   and empty means explicitly no ink; present and non-empty replaces
+   the node fills for that run. This is law 6 of decision 3 applied to
+   text, and both engines implement it identically today.
+2. **Decoration color** is a paint-only value riding on geometry the
+   layout artifact owns.
+3. **Text strokes** reuse the stroke application unchanged — no
+   text-specific stroke or paint type exists.
+
+The difference in field *coverage* between the two engines' text-style
+records (the production record carries the full layout-affecting set;
+the v2 proof deliberately carries a three-field subset) lies entirely in
+the layout-affecting half, and is therefore the text-layout RFD's
+environment-completeness concern, not a paint-model question.
+
+---
+
+## Decision 5 — Gradient and image canonical field sets
+
+### The question
+
+What exactly are the canonical fields of each non-solid paint variant?
+The point of pinning them is that import losses become **conformance
+statements** — declared, testable deviations — instead of silent drops.
+
+### Evidence
+
+- All three surfaces (production runtime, v2 proof, archive schema)
+  agree on the field sets below with two known pressure points:
+  per-stop opacity and the radial focal point.
+- The SVG import path today drops a source gradient's per-stop opacity
+  and focal point on the way to the engine model — the focal point
+  survives into the import's intermediate representation and is
+  discarded at the packing step; both drops are annotated in-source as
+  model mismatches and are invisible to the user.
+- Source SVG patterns are mapped to a transparent paint — a silent
+  erasure; pattern paint servers are a tracked capability
+  ([gridaco/nothing#14](https://github.com/gridaco/nothing/issues/14)).
+
+### The canonical field sets
+
+**Common to all six variants:** active flag, opacity, blend mode
+(decision 3). For solid paints, opacity is the color alpha (decision 1).
+
+**One parameterization rule for gradients.** Every gradient is defined
+in a normalized space over the paint target box and positioned by an
+affine transform composed as `scale(width, height) × user-transform`:
+the gradient definition itself is resolution-independent, and all
+rotation, skew, and offset live in the user transform — never baked
+into intrinsic parameters.
+
+| Variant | Intrinsic parameters                                                                 | Stops | Tile mode                     | Transform |
+| ------- | ------------------------------------------------------------------------------------ | ----- | ----------------------------- | --------- |
+| Linear  | Two endpoints as alignment points (defaults: center-left → center-right)              | Yes   | Yes                           | Yes       |
+| Radial  | Implicit center `(0.5, 0.5)`, radius `0.5` in unit gradient space                     | Yes   | Yes                           | Yes       |
+| Sweep   | Implicit center `(0.5, 0.5)`; angular domain one full turn, clockwise from 0°         | Yes   | No — the angular domain is closed; a full turn has no exterior to tile | Yes |
+| Diamond | The radial field evaluated under the Manhattan distance metric, same unit space       | Yes   | No — no tile mode is carried on any surface today; behavior beyond the unit diamond must be pinned at ratification | Yes |
+
+**Stop:** `(offset ∈ [0,1], color)` — recommended without a separate
+opacity field; see the contested point below.
+
+**Image paint:**
+
+| Field         | Type / domain                                                                                   | Notes                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| image         | Resource reference (by content hash or by logical id)                                            | Resolution is the resource system's concern                                                 |
+| quarter turns | Integer modulo 4                                                                                 | Discrete, lossless source-image orientation applied before fitting; odd turns swap intrinsic width/height |
+| alignment     | Alignment point                                                                                  | Positions the fitted image in its box                                                       |
+| fit           | One of: standard object-fit · explicit affine transform · tile (scale + repeat axes)             | Tiling is a distinct mode, composed pre-repeat, so dead combinations like cover-plus-repeat are unrepresentable |
+| opacity       | `[0,1]`                                                                                          |                                                                                             |
+| blend mode    | Per decision 3                                                                                   |                                                                                             |
+| filters       | Seven scalar adjustments — exposure, contrast, saturation, temperature, tint, highlights, shadows | Each with a declared range and neutral zero; all-zero means no filtering                    |
+
+### Contested point A — per-stop opacity
+
+| Question                                              | Fold into stop-color alpha (recommended)                       | Separate per-stop opacity field                              |
+| ----------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------ |
+| Do the engines and archive carry it today             | Yes — all three have `(offset, color)` only                    | No — a three-surface addition (schema, both engines)         |
+| Information difference                                | Effective alpha quantized to 8 bits at the fold                | Retains sub-8-bit precision of `alpha × opacity`             |
+| Authoring compatibility                                | The authored grammar of gridaco/nothing#9 already spells stop opacity separately and folds it at the boundary | Same authoring surface either way        |
+| Failure mode today                                    | Import currently *drops* stop opacity entirely — worse than folding | —                                                        |
+
+**Recommendation:** no separate field. Authored or imported per-stop
+opacity is folded into the stop color's alpha at the boundary, under the
+declared quantization policy of decision 1. **Conformance statement:**
+an importer that meets a source per-stop opacity must fold it; dropping
+it is nonconformant. The sub-8-bit precision loss is bounded by half a
+quantization step and is accepted until the wide-gamut successor of
+decision 1 revisits channel depth.
+
+### Contested point B — the radial focal point
+
+A focal (two-point) radial gradient places the 0-offset point away from
+the circle's center, producing isolines that are non-concentric circles.
+No affine transform of a concentric radial can express this: affine maps
+send concentric circles to concentric ellipses, so the focal family is
+strictly outside the current parameterization. This is why the import
+pipeline can only drop a source focal point today.
+
+| Question                                        | Keep radial concentric-only                                     | Optional focal point in unit gradient space (recommended)         | Full two-point conical (two circles)                       |
+| ----------------------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| Expressive coverage of the domain               | Loses SVG focal gradients permanently                            | Covers SVG focal semantics (focus + one circle)                   | Covers SVG and more (two radii)                            |
+| Backend support                                 | Native everywhere                                                | Native two-point conical exists in the raster backends            | Same                                                       |
+| Cost                                            | None                                                             | One optional field, defaulting to center (degenerate = today)     | Two extra parameters with no current producer              |
+| Design-tool precedent                           | Matches Figma-style radial                                       | Superset; default behavior unchanged                              | No authoring surface wants the second radius today         |
+
+**Recommendation:** extend the canonical radial with an *optional focal
+point*, expressed in unit gradient space and defaulting to the center —
+the default is byte-identical to today's behavior. Until the extension
+is ratified and lands (a schema change, so promotion-program work — the
+seam program forbids schema motion), the **conformance statement** is:
+an importer meeting a source focal point must declare the deviation in
+its import report; silent dropping is nonconformant.
+
+### Conformance statements (summary)
+
+1. Per-stop opacity: fold into stop alpha; never drop.
+2. Radial focal point: represent once ratified; until then, a declared
+   deviation, never a silent drop.
+3. Source spread/tile methods on sweep or diamond gradients: not
+   representable; declared deviation.
+4. Source pattern paint servers: not representable
+   ([gridaco/nothing#14](https://github.com/gridaco/nothing/issues/14));
+   declared deviation, never a silent transparent substitution.
+5. Any float-to-byte channel conversion: round-to-nearest unless the
+   boundary declares otherwise (decision 1).
+
+---
+
+## What promotion does to legacy types
+
+The seam program ships no type reshaping; this section states the
+contract the promotion program implements, in vocabulary terms:
+
+- **Color** — value semantics unchanged (RGBA8, straight alpha). The
+  packed interchange order is pinned to the single declared order; the
+  truncating import boundary adopts the round-to-nearest conformance
+  default; the archive's float spelling remains a boundary encoding of
+  the RGBA8 value.
+- **Stroke** — every node's flattened single stroke geometry plus
+  stroke paint stack becomes a list of exactly one stroke application.
+  Lossless; the repeatable form is a strict superset.
+- **Paint stack** — no change. The production semantics are the source
+  of truth and are now pinned here as decision 3.
+- **Text style** — the style record splits along the decision 4
+  boundary: layout-affecting values remain with the text-resolution
+  contract; run fills, decoration color, and text strokes are governed
+  by this spec.
+- **Gradients and images** — field sets unchanged except the ratified
+  radial focal extension; importers upgrade every silent drop named in
+  decision 5 to its conformance behavior.
+
+## Evidence
+
+Non-normative provenance — where the claims above were verified. The
+production engine is cited by path in this repository; the v2 proof by
+branch and path in prose.[^branch-links]
+
+- Production engine (`main`): the paint vocabulary and color value in
+  [`crates/grida/src/cg/types.rs`](../../../crates/grida/src/cg/types.rs)
+  and [`crates/grida/src/cg/color.rs`](../../../crates/grida/src/cg/color.rs);
+  the archive schema [`format/grida.fbs`](../../../format/grida.fbs)
+  (float color struct, gradient tables); the rounding archive decode in
+  [`crates/grida/src/io/io_grida_fbs.rs`](../../../crates/grida/src/io/io_grida_fbs.rs);
+  the truncating conversion and the dropped stop-opacity / focal-point
+  imports in [`crates/grida/src/import/html/mod.rs`](../../../crates/grida/src/import/html/mod.rs)
+  and [`crates/grida/src/import/svg/from_usvg.rs`](../../../crates/grida/src/import/svg/from_usvg.rs)
+  with [`crates/grida/src/import/svg/pack.rs`](../../../crates/grida/src/import/svg/pack.rs).
+- v2 proof (branch `model-v2-anchor`, locked as a design reference; see
+  [gridaco/nothing#9](https://github.com/gridaco/nothing/issues/9)):
+  the packed color, paint variants, paint stack, and unified stroke
+  application in `model-v2/a/lab/src/model.rs`.
+
+[^branch-links]: This repo's link discipline permits only `main`-target
+    repository links — no branch or commit pins — so v2 evidence on the
+    locked `model-v2-anchor` branch is cited by branch name and path in
+    prose rather than hyperlinked. The branch is reachable from the
+    tracking issue above.


### PR DESCRIPTION
The spec-first track of the **legacy seam program** (#27); deliverables of #33. Two documents, deliberately unequal in ambition:

## `docs/wg/feat-painting/paint-model.md` — Open RFD (531 lines)

The single home for the paint vocabulary both engines share at promotion. Argues all five inherited decisions to **recommendations with deciding tables** — ratification happens on #33, not in this PR:

1. **Color** — RGBA8 straight-alpha canonical; packed word as interchange identity; float→byte quantization is *caller policy* (grounded in the real in-repo divergence: archive decode rounds, HTML import truncates — the lesson #37's gate surfaced); the archive's "linear" annotation vs no-conversion runtime flagged as a must-resolve contradiction.
2. **Stroke** — geometry-carrying-ordered-paints (the stroke *application*), expressing #9's repeatable-stroke authored contract structurally; promotion law: today's flattened record ⇒ exactly one application.
3. **Ordered `Paints`** — six numbered laws pinning legacy semantics (first-bottommost, per-paint active/opacity/blend, blend locality, node-opacity non-distributivity, empty ≠ absent).
4. **Text partition** — boundary rule: layout-affecting iff it can alter resolved geometry → the text-layout RFD owns it; this spec owns run-fill tri-state, decoration color, text strokes. Nothing is decided twice.
5. **Gradients/images** — one parameterization rule (unit space × scale × user transform); per-stop opacity folds into stop alpha; radial gains an optional focal point (proved non-affine-expressible); five conformance statements replace today's silent importer drops.

## `docs/wg/feat-2d/display-list-contract.md` — design study, NOT a spec (176 lines)

Answers one question: should a shared display-list contract exist? **Conclusion: no** — the two engines' display lists are structural inverses (six-dimension comparison table; layer-tree with composite state in bases vs flat stream with paired scope commands), the leaf paint vocabulary is the entire shared surface, and no display-list spec should be authored. Three falsifiable reopen conditions are stated (wire/process crossing, a second in-repo consumer, leaf-vocabulary divergence).

## Notes for review

- **Merge after #26**: one deliberate forward-cite (`../feat-paragraph/text-layout.md`) resolves once the spec overlay lands.
- v2 evidence is cited **in prose, not links** (the links doctrine forbids branch-pinned URLs; `model-v2-anchor` paths are named with a footnote stating the choice, reachable via #9).
- Does not close #33 — the RFD is Open; the issue closes at ratification. Two known must-pin-at-ratification items are flagged inside (diamond-gradient extension behavior; the legacy tri-state run-fill assertion).