### PR TITLE
feat(text): the resolved-text artifact — legacy's realization of the text-layout RFD

### DIFF
--- a/crates/grida/src/cache/paragraph.rs
+++ b/crates/grida/src/cache/paragraph.rs
@@ -27,6 +27,12 @@
 //! - **Layout result caching**: Caches layout measurements by width to avoid redundant layout calls
 //! - **Paint strategy optimization**: Chooses between re-creation vs visit() based on paint complexity
 //! - **Font generation tracking**: Invalidates cache when fonts change
+//! - **Resolved-text artifact**: This cache is the single producer of the
+//!   immutable [`crate::text::resolved::ResolvedTextLayout`] artifact — the
+//!   engine's realization of the Universal Shaped Text Layout RFD
+//!   (`docs/wg/feat-paragraph/text-layout.md`). [`ParagraphCache::measure`]
+//!   is a projection of that artifact; painting keeps the cached Skia
+//!   `Paragraph` (geometry is the artifact's surface, paint is not).
 //!
 //! ## Usage Patterns
 //!
@@ -76,6 +82,7 @@ use crate::node::schema::NodeId;
 use crate::painter::paint;
 use crate::runtime::font_repository::FontRepository;
 use crate::runtime::render_policy::RenderIntent;
+use crate::text::resolved::{self, EnvironmentId, ResolvedTextLayout, ShapingTransform};
 use crate::text::text_style::textstyle;
 use skia_safe::textlayout;
 use std::cell::RefCell;
@@ -83,6 +90,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// Identifies a paragraph cache entry by either NodeId or shape-based hash key.
 ///
@@ -154,9 +162,33 @@ pub struct ParagraphCacheEntry {
     pub font_generation: usize,
     /// The cached Skia paragraph object
     pub paragraph: Rc<RefCell<textlayout::Paragraph>>,
-    /// Cached measurements for the last layout width — avoids re-calling
-    /// Skia `paragraph.layout()` on every access when the width hasn't changed.
-    pub cached_measurements: Option<(Option<f32>, LayoutMeasurements)>,
+    /// The resolved-text artifact extracted at the last layout width —
+    /// avoids re-calling Skia `paragraph.layout()` on every access when the
+    /// width hasn't changed. Immutable: a width or environment change
+    /// replaces it wholesale (see [`crate::text::resolved`]).
+    pub artifact: Arc<ResolvedTextLayout>,
+    /// The width constraint `artifact` was resolved under.
+    pub artifact_width: Option<f32>,
+}
+
+impl From<&ResolvedTextLayout> for LayoutMeasurements {
+    /// Measurement is a query over the resolved artifact, not a parallel
+    /// text operation: the numbers are the oracle's paragraph-level readout
+    /// carried by the artifact, verbatim.
+    fn from(artifact: &ResolvedTextLayout) -> Self {
+        let m = &artifact.metrics;
+        LayoutMeasurements {
+            height: m.height,
+            max_width: m.max_width,
+            min_intrinsic_width: m.min_intrinsic_width,
+            max_intrinsic_width: m.max_intrinsic_width,
+            alphabetic_baseline: m.alphabetic_baseline,
+            ideographic_baseline: m.ideographic_baseline,
+            longest_line: m.longest_line,
+            line_number: m.line_count,
+            did_exceed_max_lines: m.did_exceed_max_lines,
+        }
+    }
 }
 
 /// Accumulated statistics from `measure()` calls — for benchmarking only.
@@ -217,6 +249,11 @@ impl ParagraphCache {
     /// Get or create paragraph for measurement only
     /// Returns final measured metrics for the given width
     /// If id is provided, uses ID-based caching; otherwise uses shape-key-based caching
+    ///
+    /// The measurements are a projection of the resolved-text artifact this
+    /// call produces (see [`Self::resolve`]): the measurement path consumes
+    /// the artifact's logical metrics rather than re-querying the live Skia
+    /// paragraph.
     pub fn measure(
         &mut self,
         text: &str,
@@ -228,8 +265,30 @@ impl ParagraphCache {
         fonts: &FontRepository,
         id: Option<&NodeId>,
     ) -> LayoutMeasurements {
+        self.resolve(text, style, align, max_lines, ellipsis, width, fonts, id)
+            .map(|artifact| LayoutMeasurements::from(artifact.as_ref()))
+            .unwrap_or_default()
+    }
+
+    /// Resolve text into the immutable resolved-text-layout artifact
+    /// ([`crate::text::resolved`]), producing (or reusing) the cached Skia
+    /// paragraph at this choke point.
+    ///
+    /// Returns `None` only when [`Self::skip_text_measure`] is enabled (a
+    /// benchmark-only stub): no artifact is fabricated for the stub path.
+    pub fn resolve(
+        &mut self,
+        text: &str,
+        style: &TextStyleRec,
+        align: &TextAlign,
+        max_lines: &Option<usize>,
+        ellipsis: &Option<String>,
+        width: Option<f32>,
+        fonts: &FontRepository,
+        id: Option<&NodeId>,
+    ) -> Option<Arc<ResolvedTextLayout>> {
         let shape_key = Some(Self::shape_key(text, style, align, max_lines));
-        self.measure_inner(width, fonts, id, shape_key, |fonts| {
+        self.resolve_inner(width, fonts, id, shape_key, |fonts| {
             let paragraph_style =
                 crate::text::make_paragraph_style(*align, *max_lines, ellipsis.as_deref());
 
@@ -245,33 +304,43 @@ impl ParagraphCache {
             para_builder.add_text(&transformed_text);
             let paragraph = para_builder.build();
             para_builder.pop();
-            paragraph
+            let transform = match style.text_transform {
+                TextTransform::None => ShapingTransform::Identity,
+                other => ShapingTransform::Uniform(other),
+            };
+            (paragraph, transformed_text, transform)
         })
     }
 
-    /// Shared cache-hit/miss/store logic for both `measure()` and `measure_attributed()`.
+    /// Shared cache-hit/miss/store logic for both `resolve()` and
+    /// `resolve_attributed()`.
     ///
-    /// Both public measure methods delegate to this, passing different
-    /// paragraph-building closures.
+    /// Both public resolve methods delegate to this, passing different
+    /// paragraph-building closures. The closure returns the built paragraph
+    /// together with the exact shaping text it fed the shaper and the
+    /// declared source-transformation policy.
     ///
     /// - `shape_key`: when `Some`, enables shape-key-based caching (used when `id` is `None`).
     ///   When `None`, only ID-based caching is used.
-    fn measure_inner<F>(
+    fn resolve_inner<F>(
         &mut self,
         width: Option<f32>,
         fonts: &FontRepository,
         id: Option<&NodeId>,
         shape_key: Option<u64>,
         build_paragraph: F,
-    ) -> LayoutMeasurements
+    ) -> Option<Arc<ResolvedTextLayout>>
     where
-        F: FnOnce(&FontRepository) -> textlayout::Paragraph,
+        F: FnOnce(&FontRepository) -> (textlayout::Paragraph, String, ShapingTransform),
     {
         if self.skip_text_measure {
-            return LayoutMeasurements::default();
+            return None;
         }
 
         let fonts_gen = fonts.generation();
+        let environment = EnvironmentId {
+            font_generation: fonts_gen,
+        };
         self.stats.calls += 1;
 
         // Check if we have a cached paragraph
@@ -280,17 +349,23 @@ impl ParagraphCache {
             if let Some(entry) = self.entries_measurement_by_id.get_mut(node_id) {
                 if entry.font_generation == fonts_gen {
                     self.stats.cache_hits += 1;
-                    // Fast path: return cached measurements if width matches
-                    if let Some((cached_w, ref measurements)) = entry.cached_measurements {
-                        if cached_w == width {
-                            return *measurements;
-                        }
+                    // Fast path: reuse the cached artifact if width matches
+                    if entry.artifact_width == width {
+                        return Some(entry.artifact.clone());
                     }
-                    // Width changed: re-layout and cache
-                    let paragraph_rc = entry.paragraph.clone();
-                    let m = Self::compute_measurements(paragraph_rc, width);
-                    entry.cached_measurements = Some((width, m));
-                    return m;
+                    // Width changed: re-layout the same paragraph and
+                    // resolve a fresh artifact (never patched in place).
+                    let prior = entry.artifact.clone();
+                    let artifact = Arc::new(Self::resolve_with_width(
+                        entry.paragraph.clone(),
+                        width,
+                        &prior.shaping_text,
+                        prior.transform,
+                        environment,
+                    ));
+                    entry.artifact = artifact.clone();
+                    entry.artifact_width = width;
+                    return Some(artifact);
                 }
             }
         } else if let Some(hash) = shape_key {
@@ -298,32 +373,44 @@ impl ParagraphCache {
             if let Some(entry) = self.entries_measurement_by_shapekey_unstable.get_mut(&hash) {
                 if entry.font_generation == fonts_gen {
                     self.stats.cache_hits += 1;
-                    if let Some((cached_w, ref measurements)) = entry.cached_measurements {
-                        if cached_w == width {
-                            return *measurements;
-                        }
+                    if entry.artifact_width == width {
+                        return Some(entry.artifact.clone());
                     }
-                    let paragraph_rc = entry.paragraph.clone();
-                    let m = Self::compute_measurements(paragraph_rc, width);
-                    entry.cached_measurements = Some((width, m));
-                    return m;
+                    let prior = entry.artifact.clone();
+                    let artifact = Arc::new(Self::resolve_with_width(
+                        entry.paragraph.clone(),
+                        width,
+                        &prior.shaping_text,
+                        prior.transform,
+                        environment,
+                    ));
+                    entry.artifact = artifact.clone();
+                    entry.artifact_width = width;
+                    return Some(artifact);
                 }
             }
         }
         self.stats.cache_misses += 1;
 
         // Build the paragraph (expensive operation) — no paint for measurement.
-        let paragraph = build_paragraph(fonts);
+        let (paragraph, shaping_text, transform) = build_paragraph(fonts);
         let paragraph_rc = Rc::new(RefCell::new(paragraph));
 
-        // Compute measurements and cache them with the entry
-        let measurements = Self::compute_measurements(paragraph_rc.clone(), width);
+        // Resolve the artifact and cache it with the entry
+        let artifact = Arc::new(Self::resolve_with_width(
+            paragraph_rc.clone(),
+            width,
+            &shaping_text,
+            transform,
+            environment,
+        ));
 
         let entry = ParagraphCacheEntry {
             hash: shape_key.unwrap_or(0),
             font_generation: fonts_gen,
             paragraph: paragraph_rc,
-            cached_measurements: Some((width, measurements)),
+            artifact: artifact.clone(),
+            artifact_width: width,
         };
 
         // Store in the appropriate cache
@@ -334,14 +421,19 @@ impl ParagraphCache {
                 .insert(hash, entry);
         }
 
-        measurements
+        Some(artifact)
     }
 
-    /// Helper method to compute measurements for a given paragraph and width
-    fn compute_measurements(
+    /// Lay the paragraph out for the requested width (identical layout
+    /// sequence to the historical measurement path) and extract the resolved
+    /// artifact from the laid-out paragraph.
+    fn resolve_with_width(
         paragraph_rc: Rc<RefCell<textlayout::Paragraph>>,
         width: Option<f32>,
-    ) -> LayoutMeasurements {
+        shaping_text: &str,
+        transform: ShapingTransform,
+        environment: EnvironmentId,
+    ) -> ResolvedTextLayout {
         // Calculate the final layout width
         let layout_width = if let Some(width) = width {
             width
@@ -362,35 +454,29 @@ impl ParagraphCache {
             para_ref.layout(layout_width);
         }
 
-        // Get all available measurement results
-        let para_ref = paragraph_rc.borrow();
-
-        LayoutMeasurements {
-            // Basic dimensions
-            height: para_ref.height(),
-            max_width: para_ref.max_width(),
-            min_intrinsic_width: para_ref.min_intrinsic_width(),
-            max_intrinsic_width: para_ref.max_intrinsic_width(),
-
-            // Baseline information
-            alphabetic_baseline: para_ref.alphabetic_baseline(),
-            ideographic_baseline: para_ref.ideographic_baseline(),
-
-            // Line information
-            longest_line: para_ref.longest_line(),
-            line_number: para_ref.line_number(),
-            did_exceed_max_lines: para_ref.did_exceed_max_lines(),
-        }
+        // Extract the artifact from the laid-out paragraph (read-only; the
+        // paragraph keeps its layout state for painting and overlays).
+        let mut para_ref = paragraph_rc.borrow_mut();
+        resolved::resolve_from_paragraph(
+            &mut para_ref,
+            shaping_text,
+            transform,
+            width,
+            layout_width,
+            environment,
+        )
     }
 
     /// Measure an attributed string (per-run styled text) for geometry.
     ///
-    /// Unlike [`measure`], this builds a paragraph with per-run styles so that
+    /// Unlike [`measure`](Self::measure), this builds a paragraph with per-run styles so that
     /// varying font sizes, weights, and families are reflected in the measured
     /// dimensions. No paint is applied — this is geometry-only.
     ///
     /// Results are cached by node ID with the same invalidation strategy as
-    /// [`measure`].
+    /// [`measure`](Self::measure). Like [`measure`](Self::measure), the returned numbers are a
+    /// projection of the resolved-text artifact
+    /// (see [`Self::resolve_attributed`]).
     pub fn measure_attributed(
         &mut self,
         attr: &crate::cg::types::AttributedString,
@@ -401,13 +487,35 @@ impl ParagraphCache {
         fonts: &FontRepository,
         id: Option<&NodeId>,
     ) -> LayoutMeasurements {
-        self.measure_inner(width, fonts, id, None, |fonts| {
+        self.resolve_attributed(attr, align, max_lines, ellipsis, width, fonts, id)
+            .map(|artifact| LayoutMeasurements::from(artifact.as_ref()))
+            .unwrap_or_default()
+    }
+
+    /// Resolve an attributed string into the immutable
+    /// resolved-text-layout artifact ([`crate::text::resolved`]).
+    ///
+    /// Returns `None` only when [`Self::skip_text_measure`] is enabled (a
+    /// benchmark-only stub): no artifact is fabricated for the stub path.
+    pub fn resolve_attributed(
+        &mut self,
+        attr: &crate::cg::types::AttributedString,
+        align: &TextAlign,
+        max_lines: &Option<usize>,
+        ellipsis: &Option<String>,
+        width: Option<f32>,
+        fonts: &FontRepository,
+        id: Option<&NodeId>,
+    ) -> Option<Arc<ResolvedTextLayout>> {
+        self.resolve_inner(width, fonts, id, None, |fonts| {
             let paragraph_style =
                 crate::text::make_paragraph_style(*align, *max_lines, ellipsis.as_deref());
 
             let mut para_builder =
                 textlayout::ParagraphBuilder::new(&paragraph_style, fonts.font_collection());
 
+            let mut shaping_text = String::with_capacity(attr.text.len());
+            let mut any_transform = false;
             for run in &attr.runs {
                 let ctx = TextStyleRecBuildContext {
                     color: CGColor::TRANSPARENT,
@@ -418,9 +526,16 @@ impl ParagraphCache {
                 let transformed =
                     crate::text::text_transform::transform_text(run_text, run.style.text_transform);
                 para_builder.add_text(&transformed);
+                any_transform |= run.style.text_transform != TextTransform::None;
+                shaping_text.push_str(&transformed);
             }
 
-            para_builder.build()
+            let transform = if any_transform {
+                ShapingTransform::PerRun
+            } else {
+                ShapingTransform::Identity
+            };
+            (para_builder.build(), shaping_text, transform)
         })
     }
 

--- a/crates/grida/src/text/mod.rs
+++ b/crates/grida/src/text/mod.rs
@@ -1,5 +1,6 @@
 pub mod attributed_paragraph;
 pub mod paragraph_cache_layout;
+pub mod resolved;
 pub mod text_style;
 pub mod text_transform;
 

--- a/crates/grida/src/text/paragraph_cache_layout.rs
+++ b/crates/grida/src/text/paragraph_cache_layout.rs
@@ -216,8 +216,8 @@ impl ParagraphCacheLayout {
     }
 
     /// Build and layout the paragraph with **per-run** attributed styling,
-    /// handling intrinsic width for auto-width nodes (same logic as
-    /// `ParagraphCache::compute_measurements`).
+    /// handling intrinsic width for auto-width nodes (same intrinsic-width
+    /// layout sequence as `ParagraphCache`'s resolution path).
     fn rebuild_attributed(&mut self, content: &crate::text_edit::attributed_text::AttributedText) {
         let text = content.text();
         let mut para = self.build_paragraph_attributed(content);

--- a/crates/grida/src/text/resolved.rs
+++ b/crates/grida/src/text/resolved.rs
@@ -1,0 +1,1020 @@
+//! # Resolved Text Layout
+//!
+//! The legacy engine's realization of the **Universal Shaped Text Layout**
+//! RFD (`docs/wg/feat-paragraph/text-layout.md`): one immutable,
+//! backend-neutral, inspectable artifact that carries the geometry a Skia
+//! `Paragraph` resolved — lines, glyph runs, cluster mappings, logical and
+//! ink bounds — stamped with the oracle version and the resolution-environment
+//! identity that produced it.
+//!
+//! ## Anti-goal: this is not a private retained IR
+//!
+//! The artifact is **derived, immutable, and rebuilt from inputs**. It is
+//! - never serialized into `.grida` (authored source stays authoritative;
+//!   resolved geometry is derived output),
+//! - never a mutable cache value (a cache may hold an [`ResolvedTextLayout`]
+//!   behind `Arc`, but the value is replaced wholesale — never patched in
+//!   place, e.g. by a late font swap), and
+//! - never a second scene representation: it describes exactly one text
+//!   resolution under one identity.
+//!
+//! ## The geometry surface, not the paint surface
+//!
+//! Skia paragraphs cannot be cloned or repainted after creation
+//! (see `crate::cache::paragraph`), so painting keeps consuming the cached
+//! `Paragraph` object. This artifact carries **no paints**: per the RFD,
+//! geometry is fixed before rasterization and rasterization stays
+//! backend-specific.
+//!
+//! ## Index spaces
+//!
+//! A grapheme cluster, a shaping cluster, a glyph, and a caret stop are
+//! distinct concepts; this artifact does not collapse them into one index
+//! space. All byte coordinates in this module address the **shaping text**
+//! (the sequence handed to the shaper) in UTF-8 at Unicode-scalar boundaries.
+//! When [`ResolvedTextLayout::transform`] is [`ShapingTransform::Identity`],
+//! shaping-text coordinates are source-text coordinates.
+//!
+//! ## Declared gaps (oracle limitations — declared, never fabricated)
+//!
+//! Where the RFD demands something `skia_safe::textlayout::Paragraph` does
+//! not expose, the artifact declares the absence instead of inventing a
+//! value. Each gap is asserted by a conformance test
+//! (`tests/text_resolved_conformance.rs`):
+//!
+//! 1. **Caret stops** ([`ResolvedTextLayout::caret_stops`] is `None`): Skia
+//!    exposes only interactive caret queries
+//!    (`get_glyph_position_at_coordinate`, `get_rects_for_range`) on the live
+//!    `Paragraph`; it has no API that enumerates legal caret stops with
+//!    affinity. Editing consumers keep querying the live paragraph until a
+//!    later oracle version can enumerate stops.
+//! 2. **Source mapping under text transforms**
+//!    ([`ShapingTransform::Uniform`]/[`ShapingTransform::PerRun`]): when a
+//!    `text-transform` policy rewrites the source before shaping (possibly
+//!    changing byte lengths, e.g. `ß` → `SS`), Skia never sees the authored
+//!    source, so no shaping-to-source byte mapping exists. The artifact
+//!    records the policy and the shaping text; it does not fabricate source
+//!    ranges.
+//! 3. **Exact font-content identity** ([`ResolvedFontId::typeface_id`] is
+//!    process-local): Skia's `Typeface` exposes family metadata and a
+//!    process-local unique id, not a content digest of the font bytes. The
+//!    identity is inspectable but not portable or durable across processes.
+//! 4. **Environment identity is process-local** ([`EnvironmentId`]): derived
+//!    from the `FontRepository` generation counter the paragraph cache
+//!    already keys on — every environment mutation (font registration,
+//!    fallback change) bumps it — not a portable manifest of exact font
+//!    resources.
+//! 5. **Per-glyph advances** ([`ResolvedGlyphRun::glyph_advances`] is
+//!    `None`): Skia's paragraph visitor exposes glyph positions and a
+//!    run-level advance, not per-glyph shaped advances. Positions are the
+//!    authoritative per-glyph geometry.
+//! 6. **Truncation-marker labeling** ([`ResolvedGlyphRun::synthetic`]): the
+//!    visitor does not label the ellipsis run; it even aliases source byte
+//!    offsets for it. The marker is identified as the final visual run of the
+//!    final line when the oracle reports truncation, and its source mapping
+//!    is withheld ([`ResolvedGlyphRun::cluster_starts`] is `None`) so a
+//!    synthetic unit never masquerades as authored content.
+//! 7. **Omitted-by-truncation ranges**
+//!    ([`ResolvedTextLayout::omitted_by_truncation`]): Skia reports only the
+//!    consumed prefix; the omission is published as the single suffix after
+//!    it. This engine always resolves with an LTR base paragraph direction,
+//!    which is the regime where Skia's end-of-line ellipsis makes the
+//!    omission a logical suffix.
+//! 8. **The final assigned text box** is not retained here: this artifact is
+//!    produced below box assignment (the layout engine assigns the node box
+//!    *from* these measurements). The RFD's resolution identity spans both
+//!    layers; the constraint input and the width handed to the oracle are
+//!    retained ([`ResolvedTextLayout::width_constraint`],
+//!    [`ResolvedTextLayout::layout_width`]).
+//!
+//! ## Production
+//!
+//! The only producer is the paragraph cache
+//! ([`crate::cache::paragraph::ParagraphCache`]) — the existing choke point
+//! where every text node's Skia paragraph is built and measured.
+
+use crate::cg::types::TextTransform;
+use math2::rect::Rectangle;
+use skia_safe::textlayout;
+use std::ops::Range;
+
+/// The `skia-safe` version this crate pins (single source for the oracle
+/// version string). Must match the `skia-safe` dependency in `Cargo.toml`;
+/// a conformance test asserts the two stay in lockstep.
+macro_rules! pinned_skia_safe_version {
+    () => {
+        "0.93.1"
+    };
+}
+
+/// The pinned `skia-safe` version realizing the text oracle.
+pub const PINNED_SKIA_SAFE_VERSION: &str = pinned_skia_safe_version!();
+
+/// The text-oracle version stamped into every resolved artifact.
+///
+/// Identifies the complete geometry-producing policy: Skia's `skparagraph`
+/// module as bound by the pinned `skia-safe` version. Any dependency bump
+/// that can alter a glyph choice, position, line, baseline, mapping, or
+/// reported bound changes this string. "Latest" is not a valid durable
+/// oracle version.
+pub const SKPARAGRAPH_ORACLE_VERSION: &str =
+    concat!("skparagraph@skia-", pinned_skia_safe_version!());
+
+/// The resolution-environment identity a resolved artifact was produced
+/// under.
+///
+/// Process-local (declared gap 4 in the module docs): the identity is the
+/// `FontRepository` generation counter, which the repository bumps on every
+/// environment mutation — font registration, embedded-font loading, fallback
+/// configuration. A changed generation is a different environment and yields
+/// a different resolved artifact; equal generations within one process imply
+/// an identical font environment. It is not a portable manifest of exact
+/// font-content identities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EnvironmentId {
+    /// `FontRepository::generation()` at resolution time.
+    pub font_generation: usize,
+}
+
+impl EnvironmentId {
+    /// Human-readable identity label, e.g. `fontrepository@gen-42`.
+    pub fn label(&self) -> String {
+        format!("fontrepository@gen-{}", self.font_generation)
+    }
+}
+
+/// The explicit source-to-shaping-text transformation policy (RFD: a source
+/// transformation is an explicit input, never ambient behavior).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShapingTransform {
+    /// The shaping text is byte-for-byte the authored source text; all byte
+    /// coordinates in the artifact are source coordinates.
+    Identity,
+    /// One `text-transform` policy was applied to the whole source before
+    /// shaping. Byte coordinates address the transformed text; the mapping
+    /// back to authored source is a declared absence (gap 2).
+    Uniform(TextTransform),
+    /// Per-run `text-transform` policies were applied (attributed text).
+    /// Byte coordinates address the concatenated transformed text; the
+    /// mapping back to authored source is a declared absence (gap 2).
+    PerRun,
+}
+
+impl ShapingTransform {
+    /// True when shaping-text byte coordinates are source-text coordinates.
+    pub fn is_identity(&self) -> bool {
+        matches!(self, ShapingTransform::Identity)
+    }
+}
+
+/// Why a resolved line ended (RFD line construction: explicit, soft,
+/// terminal, and truncated ends are distinct; a `hard_break` bit cannot
+/// carry the distinction).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineBreakKind {
+    /// The oracle chose a wrap opportunity before more source content.
+    Soft,
+    /// An authored line terminator ended the line; the terminator is part of
+    /// the line's consumed [`ResolvedLine::source_range`].
+    Explicit,
+    /// The line reaches the end of the complete, untruncated source. Every
+    /// non-truncated paragraph has exactly one terminal line.
+    Terminal,
+    /// The paragraph's truncation policy omitted the remaining source after
+    /// this line.
+    Truncated,
+}
+
+/// Resolved direction of a shaping cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedDirection {
+    Ltr,
+    Rtl,
+}
+
+/// Paragraph-level logical metrics, verbatim from the oracle's paragraph
+/// readout. These are the numbers surrounding layout consumes; the
+/// measurement path projects them without re-querying the live paragraph.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ParagraphMetrics {
+    /// Total height of the paragraph.
+    pub height: f32,
+    /// Maximum width used during layout.
+    pub max_width: f32,
+    /// Minimum intrinsic width (tightest possible width).
+    pub min_intrinsic_width: f32,
+    /// Maximum intrinsic width (widest possible width).
+    pub max_intrinsic_width: f32,
+    /// Y position of the alphabetic baseline.
+    pub alphabetic_baseline: f32,
+    /// Y position of the ideographic baseline.
+    pub ideographic_baseline: f32,
+    /// Width of the longest line.
+    pub longest_line: f32,
+    /// The oracle's own line count. May differ from
+    /// [`ResolvedTextLayout::lines`]`.len()`: the oracle reports zero lines
+    /// for empty source, while the RFD requires one empty terminal line.
+    pub line_count: usize,
+    /// Whether the paragraph exceeded its maximum line limit (truncation
+    /// occurred).
+    pub did_exceed_max_lines: bool,
+}
+
+/// One resolved line, in block order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedLine {
+    /// Zero-based index in block order.
+    pub index: usize,
+    /// The complete shaping-text UTF-8 range this line consumed, including
+    /// any consumed line terminator. Ranges of consecutive lines are
+    /// contiguous; under truncation the final line's range ends where
+    /// consumption stopped (see
+    /// [`ResolvedTextLayout::omitted_by_truncation`]).
+    pub source_range: Range<usize>,
+    /// Why the line ended.
+    pub break_kind: LineBreakKind,
+    /// Baseline y position from the top of the paragraph.
+    pub baseline: f32,
+    /// Ascent above the baseline (positive).
+    pub ascent: f32,
+    /// Descent below the baseline (positive).
+    pub descent: f32,
+    /// Left edge of the line's advance extent.
+    pub left: f32,
+    /// Advance width of the line.
+    pub width: f32,
+    /// Logical line box: `[left, baseline - ascent] × [width, ascent +
+    /// descent]`, in paragraph-local coordinates. Includes advance space
+    /// without glyph ink.
+    pub logical_bounds: Rectangle,
+    /// Union of glyph ink on this line; `None` when the line draws nothing
+    /// (empty line, whitespace-only coverage) or when the oracle supplied no
+    /// per-glyph ink for its runs.
+    pub ink_bounds: Option<Rectangle>,
+    /// True when this line was synthesized by the realization to satisfy the
+    /// RFD's terminal-line requirement where the oracle under-reports (empty
+    /// source resolves to one empty terminal line). Its metrics derive from
+    /// the oracle's paragraph-level readout, not invented constants.
+    pub synthesized: bool,
+}
+
+/// The resolved identity of the exact face that shaped a run.
+///
+/// Post-fallback: this names the face the oracle actually selected, which
+/// may differ from the requested family. Glyph identifiers in
+/// [`ResolvedGlyphRun::glyph_ids`] are meaningful only together with this
+/// identity. `typeface_id` is process-local (declared gap 3): Skia exposes
+/// no font-content digest, so the identity is inspectable but not portable.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedFontId {
+    /// Resolved family name of the selected typeface.
+    pub family: String,
+    /// Effective font size in logical units.
+    pub size: f32,
+    /// Resolved weight (CSS-scale, e.g. 400).
+    pub weight: i32,
+    /// Whether the resolved face is italic/oblique.
+    pub italic: bool,
+    /// Skia's process-local typeface unique id. Not portable, not durable.
+    pub typeface_id: u32,
+}
+
+/// A run of positioned glyphs shaped with one exact face, in paint (visual)
+/// order within its line.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedGlyphRun {
+    /// Index into [`ResolvedTextLayout::lines`].
+    pub line: usize,
+    /// The exact resolved face for every glyph in this run.
+    pub font: ResolvedFontId,
+    /// True for a layout-owned synthetic unit (the truncation marker). A
+    /// synthetic run has no authored source mapping
+    /// ([`Self::cluster_starts`] is `None`) and must never be treated as
+    /// authored content by copy, editing, or accessibility traversal.
+    pub synthetic: bool,
+    /// Glyph identifiers in paint order, meaningful only with [`Self::font`].
+    pub glyph_ids: Vec<u16>,
+    /// Per-glyph pen positions in paragraph-local coordinates (fractional;
+    /// no device rounding), paint order. `positions[i]` pairs with
+    /// `glyph_ids[i]`.
+    pub positions: Vec<[f32; 2]>,
+    /// Per-glyph tight ink bounds in paragraph-local coordinates, paint
+    /// order, when the oracle supplied them.
+    pub ink_bounds: Option<Vec<Rectangle>>,
+    /// Per-glyph shaping-text UTF-8 cluster start offsets, paint order.
+    /// Glyphs sharing a start belong to one shaping cluster. `None` for a
+    /// synthetic run (gap 6): the oracle aliases source offsets for the
+    /// truncation marker, and a synthetic unit must not claim source
+    /// coverage.
+    pub cluster_starts: Option<Vec<usize>>,
+    /// Advance width of the whole run.
+    pub advance_width: f32,
+    /// Declared absence (gap 5): Skia's visitor does not expose per-glyph
+    /// shaped advances. Always `None` under this oracle; positions are the
+    /// authoritative per-glyph geometry.
+    pub glyph_advances: Option<Vec<f32>>,
+}
+
+/// One shaping cluster: a unit emitted by shaping that relates a
+/// shaping-text range to zero or more positioned glyphs.
+///
+/// Not a grapheme cluster, not a glyph, not a caret stop — the index spaces
+/// are distinct and deliberately not collapsed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedCluster {
+    /// The cluster's shaping-text UTF-8 range.
+    pub range: Range<usize>,
+    /// Index into [`ResolvedTextLayout::lines`].
+    pub line: usize,
+    /// `(run index, glyph index range within the run)` of the glyphs this
+    /// cluster produced, or `None` for a zero-glyph cluster (a line
+    /// terminator, or trailing whitespace the oracle trimmed from visual
+    /// runs at a soft wrap) — such source still maps to a line and retains
+    /// its advance geometry.
+    pub glyph_span: Option<(usize, Range<usize>)>,
+    /// Resolved direction of this cluster.
+    pub direction: ResolvedDirection,
+    /// The cluster's logical advance box in paragraph-local coordinates
+    /// (its share of the line's advance extent — not glyph ink).
+    pub advance_bounds: Rectangle,
+}
+
+/// Caret affinity at a bidirectional or line boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaretAffinity {
+    Upstream,
+    Downstream,
+}
+
+/// A legal editing boundary with a visual position (RFD vocabulary). Never
+/// populated under this oracle — see [`ResolvedTextLayout::caret_stops`]
+/// (declared gap 1).
+#[derive(Debug, Clone, PartialEq)]
+pub struct CaretStop {
+    /// Shaping-text UTF-8 offset of the boundary.
+    pub byte_offset: usize,
+    /// Index into [`ResolvedTextLayout::lines`].
+    pub line: usize,
+    /// Visual x position in paragraph-local coordinates.
+    pub x: f32,
+    /// Affinity of the stop.
+    pub affinity: CaretAffinity,
+}
+
+/// The immutable, self-identifying result of resolving one text input under
+/// one identity. See the module docs for the contract and the declared gaps.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedTextLayout {
+    /// The versioned oracle that produced this result
+    /// ([`SKPARAGRAPH_ORACLE_VERSION`]).
+    pub oracle_version: &'static str,
+    /// The resolution-environment identity this result was produced under.
+    pub environment: EnvironmentId,
+    /// The exact inline constraint input; `None` means the inline axis was
+    /// unconstrained and the oracle laid out at its intrinsic width.
+    pub width_constraint: Option<f32>,
+    /// The width actually handed to the oracle's layout (the constraint, or
+    /// the measured intrinsic width when unconstrained).
+    pub layout_width: f32,
+    /// The explicit source-to-shaping transformation policy.
+    pub transform: ShapingTransform,
+    /// The exact text handed to the shaper. All byte coordinates in this
+    /// artifact address this string.
+    pub shaping_text: String,
+    /// Paragraph-level logical metrics, verbatim from the oracle.
+    pub metrics: ParagraphMetrics,
+    /// Lines in block order.
+    pub lines: Vec<ResolvedLine>,
+    /// Glyph runs in paint order (line by line, visual order within a line).
+    pub glyph_runs: Vec<ResolvedGlyphRun>,
+    /// Shaping clusters in logical (source) order.
+    pub clusters: Vec<ResolvedCluster>,
+    /// Union of the lines' logical boxes: layout extent including advance
+    /// space without ink.
+    pub logical_bounds: Rectangle,
+    /// Union of glyph ink across all runs; `None` when nothing draws ink.
+    /// Base drawing extents before node paints, strokes, or effects.
+    pub ink_bounds: Option<Rectangle>,
+    /// Glyphs the oracle could not resolve under the font environment
+    /// (rendered as tofu by this permissive engine — reported, never
+    /// silent). `None` when the oracle did not report a count.
+    pub unresolved_glyphs: Option<usize>,
+    /// The shaping-text suffix omitted by the truncation policy, when
+    /// truncation occurred (gap 7: published as the single post-visible
+    /// suffix, which is Skia's omission model under this engine's LTR base
+    /// direction).
+    pub omitted_by_truncation: Option<Range<usize>>,
+    /// Consumed shaping-text ranges the oracle declined to map to any
+    /// cluster. Expected empty; a non-empty value is an honest report of an
+    /// oracle mapping hole, never silently dropped coverage.
+    pub unmapped_ranges: Vec<Range<usize>>,
+    /// Declared absence (gap 1): Skia does not enumerate legal caret stops
+    /// with affinity. Always `None` under this oracle; editing consumers
+    /// keep querying the live paragraph.
+    pub caret_stops: Option<Vec<CaretStop>>,
+}
+
+impl ResolvedTextLayout {
+    /// The line containing the given shaping-text byte offset, by consumed
+    /// range. Offsets at `shaping_text.len()` map to the last line.
+    pub fn line_at_byte(&self, offset: usize) -> Option<usize> {
+        self.lines
+            .iter()
+            .position(|l| l.source_range.contains(&offset))
+            .or_else(|| {
+                (offset == self.shaping_text.len() && !self.lines.is_empty())
+                    .then_some(self.lines.len() - 1)
+            })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extraction from a laid-out Skia paragraph
+// ---------------------------------------------------------------------------
+
+/// Raw per-run capture from `Paragraph::visit` / `Paragraph::extended_visit`.
+struct VisitRun {
+    line: usize,
+    font: ResolvedFontId,
+    advance_width: f32,
+    glyph_ids: Vec<u16>,
+    /// Paragraph-local absolute pen positions (`origin + position`).
+    positions: Vec<[f32; 2]>,
+    /// Paragraph-absolute UTF-8 cluster start per glyph, plus the visitor's
+    /// end sentinel (valid only for LTR runs).
+    utf8_starts: Vec<u32>,
+    /// Paragraph-local absolute per-glyph ink bounds, when captured.
+    ink_bounds: Option<Vec<Rectangle>>,
+}
+
+/// Extract a [`ResolvedTextLayout`] from a laid-out Skia paragraph.
+///
+/// `paragraph` must already be laid out at `layout_width`. The extraction
+/// only reads; it never re-layouts, so the caller's paragraph keeps its
+/// state for painting.
+pub(crate) fn resolve_from_paragraph(
+    paragraph: &mut textlayout::Paragraph,
+    shaping_text: &str,
+    transform: ShapingTransform,
+    width_constraint: Option<f32>,
+    layout_width: f32,
+    environment: EnvironmentId,
+) -> ResolvedTextLayout {
+    let metrics = ParagraphMetrics {
+        height: paragraph.height(),
+        max_width: paragraph.max_width(),
+        min_intrinsic_width: paragraph.min_intrinsic_width(),
+        max_intrinsic_width: paragraph.max_intrinsic_width(),
+        alphabetic_baseline: paragraph.alphabetic_baseline(),
+        ideographic_baseline: paragraph.ideographic_baseline(),
+        longest_line: paragraph.longest_line(),
+        line_count: paragraph.line_number(),
+        did_exceed_max_lines: paragraph.did_exceed_max_lines(),
+    };
+
+    let (mut lines, omitted_by_truncation) = extract_lines(paragraph, shaping_text, &metrics);
+    let raw_runs = capture_visit_runs(paragraph);
+    // Gap 6: when the oracle truncated, the truncation marker is the final
+    // visual run of the final line. The visitor aliases source offsets for
+    // it, so its source mapping is withheld below.
+    let synthetic_run = if metrics.did_exceed_max_lines && !raw_runs.is_empty() {
+        Some(raw_runs.len() - 1)
+    } else {
+        None
+    };
+    let mut unmapped_ranges = Vec::new();
+    let clusters = extract_clusters(
+        paragraph,
+        &lines,
+        &raw_runs,
+        synthetic_run,
+        &mut unmapped_ranges,
+    );
+    let glyph_runs = finalize_runs(raw_runs, synthetic_run);
+
+    // Per-line and paragraph ink: union of per-glyph ink of the line's runs.
+    for line in lines.iter_mut() {
+        let mut acc: Option<Rectangle> = None;
+        for run in glyph_runs.iter().filter(|r| r.line == line.index) {
+            if let Some(bounds) = &run.ink_bounds {
+                for b in bounds {
+                    acc = Some(match acc {
+                        Some(a) => union(a, *b),
+                        None => *b,
+                    });
+                }
+            }
+        }
+        line.ink_bounds = acc;
+    }
+    let ink_bounds = lines.iter().filter_map(|l| l.ink_bounds).reduce(union);
+    let logical_bounds = lines
+        .iter()
+        .map(|l| l.logical_bounds)
+        .reduce(union)
+        .unwrap_or(Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 0.0,
+            height: 0.0,
+        });
+
+    ResolvedTextLayout {
+        oracle_version: SKPARAGRAPH_ORACLE_VERSION,
+        environment,
+        width_constraint,
+        layout_width,
+        transform,
+        shaping_text: shaping_text.to_owned(),
+        metrics,
+        lines,
+        glyph_runs,
+        clusters,
+        logical_bounds,
+        ink_bounds,
+        unresolved_glyphs: paragraph.unresolved_glyphs(),
+        omitted_by_truncation,
+        unmapped_ranges,
+        caret_stops: None, // Gap 1: declared absence, never estimated.
+    }
+}
+
+fn union(a: Rectangle, b: Rectangle) -> Rectangle {
+    let x0 = a.x.min(b.x);
+    let y0 = a.y.min(b.y);
+    let x1 = (a.x + a.width).max(b.x + b.width);
+    let y1 = (a.y + a.height).max(b.y + b.height);
+    Rectangle {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    }
+}
+
+/// Whether `s` ends in a hard line terminator the oracle breaks on
+/// (`\n`/`\r\n`, VT, FF, NEL, LS, PS — a bare `\r` is not a break for
+/// this oracle).
+fn ends_with_hard_terminator(s: &str) -> bool {
+    s.ends_with([
+        '\n', '\u{000B}', '\u{000C}', '\u{0085}', '\u{2028}', '\u{2029}',
+    ])
+}
+
+/// Incremental UTF-16 → UTF-8 offset converter over `text`. Targets must be
+/// non-decreasing across calls.
+struct Utf16ToUtf8<'a> {
+    text: &'a str,
+    iter: std::iter::Peekable<std::str::CharIndices<'a>>,
+    run_u16: usize,
+    run_byte: usize,
+}
+
+impl<'a> Utf16ToUtf8<'a> {
+    fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            iter: text.char_indices().peekable(),
+            run_u16: 0,
+            run_byte: 0,
+        }
+    }
+
+    fn convert(&mut self, target_u16: usize) -> usize {
+        while self.run_u16 < target_u16 {
+            if let Some(&(byte_idx, ch)) = self.iter.peek() {
+                self.run_u16 += ch.len_utf16();
+                self.run_byte = byte_idx + ch.len_utf8();
+                self.iter.next();
+            } else {
+                break;
+            }
+        }
+        self.run_byte.min(self.text.len())
+    }
+}
+
+/// Build the RFD line list from Skia's UTF-16 line metrics.
+///
+/// Normalizations (documented, oracle-sourced):
+/// - Consumed ranges are derived from consecutive line starts, so each line
+///   includes its consumed terminator.
+/// - When the source ends in a line terminator, Skia emits the trailing
+///   empty line but repeats the previous line's indices for it; the terminal
+///   empty line is normalized to `[len, len)`.
+/// - Empty source: Skia reports zero lines; one empty terminal line is
+///   synthesized from the oracle's paragraph-level metrics.
+fn extract_lines(
+    paragraph: &textlayout::Paragraph,
+    shaping_text: &str,
+    metrics: &ParagraphMetrics,
+) -> (Vec<ResolvedLine>, Option<Range<usize>>) {
+    let len = shaping_text.len();
+    let skia_lines = paragraph.get_line_metrics();
+
+    if skia_lines.is_empty() {
+        // RFD: an empty source resolves to one empty terminal line carrying
+        // line metrics, without inventing a source character. Metrics derive
+        // from the oracle's paragraph readout for the empty paragraph.
+        let baseline = metrics.alphabetic_baseline;
+        let ascent = baseline;
+        let descent = (metrics.height - baseline).max(0.0);
+        let line = ResolvedLine {
+            index: 0,
+            source_range: 0..0,
+            break_kind: LineBreakKind::Terminal,
+            baseline,
+            ascent,
+            descent,
+            left: 0.0,
+            width: 0.0,
+            logical_bounds: Rectangle {
+                x: 0.0,
+                y: baseline - ascent,
+                width: 0.0,
+                height: ascent + descent,
+            },
+            ink_bounds: None,
+            synthesized: true,
+        };
+        return (vec![line], None);
+    }
+
+    let mut conv = Utf16ToUtf8::new(shaping_text);
+    let mut starts_u8: Vec<usize> = Vec::with_capacity(skia_lines.len());
+    for lm in &skia_lines {
+        starts_u8.push(conv.convert(lm.start_index));
+    }
+    // The truncated final line's consumed end is its own end index; every
+    // other boundary is the next line's start.
+    let last_end_u8 = if metrics.did_exceed_max_lines {
+        conv.convert(skia_lines[skia_lines.len() - 1].end_index)
+    } else {
+        len
+    };
+
+    // Skia emits a trailing empty line when the source ends in a hard
+    // terminator, but repeats the previous line's indices for it; normalize
+    // that degenerate line to the empty range at the end of the source. The
+    // guard (>= 2 lines, zero-width last line) keeps the normalization from
+    // ever touching a real final line.
+    let ends_in_terminator = !metrics.did_exceed_max_lines
+        && skia_lines.len() >= 2
+        && skia_lines[skia_lines.len() - 1].width == 0.0
+        && ends_with_hard_terminator(shaping_text);
+    if ends_in_terminator {
+        if let Some(last) = starts_u8.last_mut() {
+            *last = len;
+        }
+    }
+
+    let line_count = skia_lines.len();
+    let mut lines: Vec<ResolvedLine> = Vec::with_capacity(line_count);
+    for (i, lm) in skia_lines.iter().enumerate() {
+        let start = starts_u8[i];
+        let end = if i + 1 < line_count {
+            starts_u8[i + 1]
+        } else {
+            last_end_u8
+        };
+        let start = start.min(end);
+        let is_last = i + 1 == line_count;
+        let consumed = &shaping_text[start..end];
+        let break_kind = if is_last {
+            if metrics.did_exceed_max_lines {
+                LineBreakKind::Truncated
+            } else {
+                LineBreakKind::Terminal
+            }
+        } else if ends_with_hard_terminator(consumed) {
+            LineBreakKind::Explicit
+        } else {
+            LineBreakKind::Soft
+        };
+
+        let baseline = lm.baseline as f32;
+        let ascent = lm.ascent as f32;
+        let descent = lm.descent as f32;
+        let left = lm.left as f32;
+        let width = lm.width as f32;
+        lines.push(ResolvedLine {
+            index: i,
+            source_range: start..end,
+            break_kind,
+            baseline,
+            ascent,
+            descent,
+            left,
+            width,
+            logical_bounds: Rectangle {
+                x: left,
+                y: baseline - ascent,
+                width,
+                height: ascent + descent,
+            },
+            ink_bounds: None,
+            synthesized: false,
+        });
+    }
+
+    let omitted = if metrics.did_exceed_max_lines && last_end_u8 < len {
+        Some(last_end_u8..len)
+    } else {
+        None
+    };
+    (lines, omitted)
+}
+
+/// Capture glyph runs via `visit` (absolute UTF-8 cluster starts, fonts,
+/// positions) zipped with `extended_visit` (per-glyph ink bounds).
+fn capture_visit_runs(paragraph: &mut textlayout::Paragraph) -> Vec<VisitRun> {
+    let mut runs: Vec<VisitRun> = Vec::new();
+    paragraph.visit(|line, info| {
+        if let Some(info) = info {
+            let origin = info.origin();
+            let font = info.font();
+            let typeface = font.typeface();
+            let style = typeface.font_style();
+            let positions = info
+                .positions()
+                .iter()
+                .map(|p| [p.x + origin.x, p.y + origin.y])
+                .collect();
+            runs.push(VisitRun {
+                line,
+                font: ResolvedFontId {
+                    family: typeface.family_name(),
+                    size: font.size(),
+                    weight: *style.weight(),
+                    italic: typeface.is_italic(),
+                    typeface_id: typeface.unique_id(),
+                },
+                advance_width: info.advance_x(),
+                glyph_ids: info.glyphs().to_vec(),
+                positions,
+                utf8_starts: info.utf8_starts().to_vec(),
+                ink_bounds: None,
+            });
+        }
+    });
+
+    // Second pass: per-glyph ink bounds. The extended visitor iterates the
+    // same visual runs; zip by order and cross-check glyph identity. On any
+    // mismatch the ink stays a declared `None` rather than misattributed.
+    let mut index = 0usize;
+    paragraph.extended_visit(|line, info| {
+        if let Some(info) = info {
+            if let Some(run) = runs.get_mut(index) {
+                if run.line == line && run.glyph_ids.as_slice() == info.glyphs() {
+                    let origin = info.origin();
+                    let positions = info.positions();
+                    let ink = info
+                        .bounds()
+                        .iter()
+                        .zip(positions.iter())
+                        .map(|(b, p)| Rectangle {
+                            x: b.left + p.x + origin.x,
+                            y: b.top + p.y + origin.y,
+                            width: b.right - b.left,
+                            height: b.bottom - b.top,
+                        })
+                        .collect();
+                    run.ink_bounds = Some(ink);
+                } else {
+                    debug_assert!(false, "visit/extended_visit run order diverged");
+                }
+            }
+            index += 1;
+        }
+    });
+
+    runs
+}
+
+/// Convert raw visitor captures into the published run vocabulary.
+fn finalize_runs(raw: Vec<VisitRun>, synthetic_run: Option<usize>) -> Vec<ResolvedGlyphRun> {
+    raw.into_iter()
+        .enumerate()
+        .map(|(i, run)| {
+            let synthetic = synthetic_run == Some(i);
+            let glyph_count = run.glyph_ids.len();
+            let cluster_starts = if synthetic {
+                // A synthetic unit must never masquerade as authored content.
+                None
+            } else {
+                Some(
+                    run.utf8_starts
+                        .iter()
+                        .take(glyph_count)
+                        .map(|&s| s as usize)
+                        .collect(),
+                )
+            };
+            ResolvedGlyphRun {
+                line: run.line,
+                font: run.font,
+                synthetic,
+                glyph_ids: run.glyph_ids,
+                positions: run.positions,
+                ink_bounds: run.ink_bounds,
+                cluster_starts,
+                advance_width: run.advance_width,
+                // Gap 5: the visitor exposes no per-glyph advances.
+                glyph_advances: None,
+            }
+        })
+        .collect()
+}
+
+/// Derive the shaping-cluster ledger.
+///
+/// Glyph-backed clusters come from the visitor's per-glyph cluster starts
+/// (consecutive glyphs sharing a start form one cluster); their advance
+/// boxes partition each run's advance extent at the cluster's first visual
+/// pen position. Direction derives from the monotonicity of cluster starts
+/// within the run; runs with a single cluster are disambiguated with one
+/// direct oracle query. The logically-last cluster's end comes from the
+/// visitor's end sentinel for LTR runs and from one oracle query for RTL
+/// runs (whose sentinel is not meaningful). Consumed source not covered by
+/// any visual glyph (line terminators, whitespace trimmed at a soft wrap) is
+/// recovered with targeted oracle queries so the artifact keeps a complete
+/// source-disposition ledger; anything the oracle declines to map is
+/// reported in `unmapped_ranges`.
+fn extract_clusters(
+    paragraph: &textlayout::Paragraph,
+    lines: &[ResolvedLine],
+    raw_runs: &[VisitRun],
+    synthetic_run: Option<usize>,
+    unmapped_ranges: &mut Vec<Range<usize>>,
+) -> Vec<ResolvedCluster> {
+    let mut clusters: Vec<ResolvedCluster> = Vec::new();
+
+    for (run_index, run) in raw_runs.iter().enumerate() {
+        if synthetic_run == Some(run_index) {
+            continue; // synthetic marker: no authored source coverage
+        }
+        let glyph_count = run.glyph_ids.len();
+        if glyph_count == 0 {
+            continue;
+        }
+        let line = &lines[run.line];
+
+        // Group consecutive glyphs sharing a cluster start (visual order).
+        struct Group {
+            start: usize,
+            glyphs: Range<usize>,
+            visual_x: f32,
+        }
+        let mut groups: Vec<Group> = Vec::new();
+        for gi in 0..glyph_count {
+            let s = run.utf8_starts[gi] as usize;
+            match groups.last_mut() {
+                Some(g) if g.start == s => {
+                    g.glyphs.end = gi + 1;
+                    g.visual_x = g.visual_x.min(run.positions[gi][0]);
+                }
+                _ => groups.push(Group {
+                    start: s,
+                    glyphs: gi..gi + 1,
+                    visual_x: run.positions[gi][0],
+                }),
+            }
+        }
+
+        // Direction from monotonicity of starts across groups; a
+        // single-cluster run is resolved with one oracle query.
+        let direction = if groups.len() > 1 {
+            if groups.windows(2).all(|w| w[0].start < w[1].start) {
+                ResolvedDirection::Ltr
+            } else {
+                ResolvedDirection::Rtl
+            }
+        } else {
+            match paragraph.get_glyph_cluster_at(groups[0].start) {
+                Some(info) if info.position == textlayout::TextDirection::RTL => {
+                    ResolvedDirection::Rtl
+                }
+                _ => ResolvedDirection::Ltr,
+            }
+        };
+
+        // Logical range end per group: the next logical start within the
+        // run; the logically-last group's end comes from the visitor's end
+        // sentinel (LTR) or one oracle query (RTL).
+        let mut logical_order: Vec<usize> = (0..groups.len()).collect();
+        logical_order.sort_by_key(|&i| groups[i].start);
+        let last_logical = *logical_order.last().unwrap();
+        let run_logical_end = match direction {
+            ResolvedDirection::Ltr => run.utf8_starts[glyph_count] as usize,
+            ResolvedDirection::Rtl => paragraph
+                .get_glyph_cluster_at(groups[last_logical].start)
+                .map(|info| info.text_range.end)
+                .unwrap_or(groups[last_logical].start),
+        };
+
+        // Visual boundaries: sorted first-glyph x positions partition the
+        // run's advance extent [min_x, min_x + advance].
+        let run_left = groups
+            .iter()
+            .map(|g| g.visual_x)
+            .fold(f32::INFINITY, f32::min);
+        let mut visual_order: Vec<usize> = (0..groups.len()).collect();
+        visual_order.sort_by(|&a, &b| {
+            groups[a]
+                .visual_x
+                .partial_cmp(&groups[b].visual_x)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let mut right_edge = vec![0.0f32; groups.len()];
+        for (vi, &gi) in visual_order.iter().enumerate() {
+            right_edge[gi] = if vi + 1 < visual_order.len() {
+                groups[visual_order[vi + 1]].visual_x
+            } else {
+                run_left + run.advance_width
+            };
+        }
+
+        let top = line.baseline - line.ascent;
+        let height = line.ascent + line.descent;
+        for (li, &gi) in logical_order.iter().enumerate() {
+            let g = &groups[gi];
+            let end = if li + 1 < logical_order.len() {
+                groups[logical_order[li + 1]].start
+            } else {
+                run_logical_end
+            };
+            clusters.push(ResolvedCluster {
+                range: g.start..end.max(g.start),
+                line: run.line,
+                glyph_span: Some((run_index, g.glyphs.clone())),
+                direction,
+                advance_bounds: Rectangle {
+                    x: g.visual_x,
+                    y: top,
+                    width: (right_edge[gi] - g.visual_x).max(0.0),
+                    height,
+                },
+            });
+        }
+    }
+
+    clusters.sort_by_key(|c| (c.range.start, c.range.end));
+
+    // Recover consumed source with no visual glyph (terminators, trimmed
+    // trailing whitespace) via targeted oracle queries, line by line.
+    let mut recovered: Vec<ResolvedCluster> = Vec::new();
+    for line in lines {
+        let mut gaps: Vec<Range<usize>> = Vec::new();
+        {
+            let mut cursor = line.source_range.start;
+            let mut covered: Vec<&ResolvedCluster> =
+                clusters.iter().filter(|c| c.line == line.index).collect();
+            covered.sort_by_key(|c| c.range.start);
+            for c in covered {
+                if c.range.start > cursor {
+                    gaps.push(cursor..c.range.start);
+                }
+                cursor = cursor.max(c.range.end);
+            }
+            if cursor < line.source_range.end {
+                gaps.push(cursor..line.source_range.end);
+            }
+        }
+        for gap in gaps {
+            let mut at = gap.start;
+            while at < gap.end {
+                match paragraph.get_glyph_cluster_at(at) {
+                    Some(info) if info.text_range.end > at => {
+                        let end = info.text_range.end.min(gap.end);
+                        recovered.push(ResolvedCluster {
+                            range: at..end,
+                            line: line.index,
+                            glyph_span: None,
+                            direction: if info.position == textlayout::TextDirection::RTL {
+                                ResolvedDirection::Rtl
+                            } else {
+                                ResolvedDirection::Ltr
+                            },
+                            advance_bounds: Rectangle {
+                                x: info.bounds.left,
+                                y: info.bounds.top,
+                                width: info.bounds.right - info.bounds.left,
+                                height: info.bounds.bottom - info.bounds.top,
+                            },
+                        });
+                        at = end;
+                    }
+                    _ => {
+                        // The oracle declined to map this consumed range:
+                        // report it, never silently drop it.
+                        unmapped_ranges.push(at..gap.end);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    clusters.extend(recovered);
+    clusters.sort_by_key(|c| (c.range.start, c.range.end));
+    clusters
+}

--- a/crates/grida/tests/text_resolved_conformance.rs
+++ b/crates/grida/tests/text_resolved_conformance.rs
@@ -1,0 +1,688 @@
+//! Conformance suite for the resolved-text-layout artifact
+//! (`crate::text::resolved`) against the Universal Shaped Text Layout RFD
+//! (`docs/wg/feat-paragraph/text-layout.md`).
+//!
+//! Test names carry the RFD's scenario vocabulary verbatim so conformance
+//! drops stay grep-able across engines. Where the Skia oracle cannot supply
+//! what the RFD demands, the artifact declares the absence and a test here
+//! asserts the *declared* absence (see the module docs' "Declared gaps").
+//!
+//! Fonts: the deterministic embedded Geist face, plus the Noto Sans Hebrew
+//! fixture (`fixtures/fonts/Noto_Sans_Hebrew`) for bidirectional scenarios —
+//! no system fonts, so results are machine-independent.
+
+use std::sync::{Arc, Mutex};
+
+use grida::cache::paragraph::{LayoutMeasurements, ParagraphCache};
+use grida::cg::prelude::*;
+use grida::node::factory::NodeFactory;
+use grida::resources::ByteStore;
+use grida::runtime::font_repository::FontRepository;
+use grida::text::resolved::{
+    LineBreakKind, ResolvedDirection, ResolvedTextLayout, ShapingTransform,
+    PINNED_SKIA_SAFE_VERSION, SKPARAGRAPH_ORACLE_VERSION,
+};
+
+const NOTO_HEBREW: &[u8] = include_bytes!(
+    "../../../fixtures/fonts/Noto_Sans_Hebrew/NotoSansHebrew-VariableFont_wdth,wght.ttf"
+);
+const BUNGEE_REGULAR: &[u8] = include_bytes!("../../../fixtures/fonts/Bungee/Bungee-Regular.ttf");
+
+struct Ctx {
+    store: Arc<Mutex<ByteStore>>,
+    fonts: FontRepository,
+    cache: ParagraphCache,
+    style: TextStyleRec,
+    align: TextAlign,
+}
+
+impl Ctx {
+    fn new() -> Self {
+        let store = Arc::new(Mutex::new(ByteStore::new()));
+        let mut fonts = FontRepository::new(store.clone());
+        fonts.register_embedded_fonts();
+        let node = NodeFactory::new().create_text_span_node();
+        Self {
+            store,
+            fonts,
+            cache: ParagraphCache::new(),
+            style: node.text_style,
+            align: node.text_align,
+        }
+    }
+
+    fn with_hebrew_fallback() -> Self {
+        let mut ctx = Self::new();
+        let hash = 0x4845_4252_u64;
+        ctx.store.lock().unwrap().insert(hash, NOTO_HEBREW.to_vec());
+        ctx.fonts.add(hash, "Noto Sans Hebrew");
+        ctx.fonts
+            .set_user_fallback_families(vec!["Noto Sans Hebrew".to_string()]);
+        ctx
+    }
+
+    fn resolve(&mut self, text: &str, width: Option<f32>) -> Arc<ResolvedTextLayout> {
+        self.cache
+            .resolve(
+                text,
+                &self.style,
+                &self.align,
+                &None,
+                &None,
+                width,
+                &self.fonts,
+                None,
+            )
+            .expect("resolution must publish an artifact")
+    }
+
+    fn resolve_truncated(&mut self, text: &str, width: Option<f32>) -> Arc<ResolvedTextLayout> {
+        self.cache
+            .resolve(
+                text,
+                &self.style,
+                &self.align,
+                &Some(1),
+                &Some("…".to_string()),
+                width,
+                &self.fonts,
+                None,
+            )
+            .expect("resolution must publish an artifact")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution identity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolution_identity_records_the_oracle_version_and_environment_identity() {
+    let mut ctx = Ctx::new();
+    let artifact = ctx.resolve("hello", None);
+    assert_eq!(artifact.oracle_version, SKPARAGRAPH_ORACLE_VERSION);
+    assert_eq!(artifact.oracle_version, "skparagraph@skia-0.93.1");
+    assert_eq!(
+        artifact.environment.font_generation,
+        ctx.fonts.generation(),
+        "the environment recorded by the artifact must be exactly the one used to produce it"
+    );
+    assert_eq!(
+        artifact.environment.label(),
+        format!("fontrepository@gen-{}", ctx.fonts.generation())
+    );
+}
+
+#[test]
+fn the_oracle_version_matches_the_pinned_skia_safe_dependency() {
+    // "Latest" is not a valid durable oracle version: the stamped version is
+    // derived from one pinned const, and this test keeps that const in
+    // lockstep with the actual Cargo dependency pin.
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("crate manifest must be readable");
+    let line = manifest
+        .lines()
+        .find(|l| l.trim_start().starts_with("skia-safe"))
+        .expect("Cargo.toml must pin skia-safe");
+    let needle = "version = \"";
+    let start = line.find(needle).expect("skia-safe pin must be explicit") + needle.len();
+    let end = start + line[start..].find('"').expect("unterminated version");
+    let pinned_in_manifest = &line[start..end];
+    assert_eq!(
+        PINNED_SKIA_SAFE_VERSION, pinned_in_manifest,
+        "resolved::PINNED_SKIA_SAFE_VERSION must match the skia-safe pin in Cargo.toml \
+         (bump both together: a skia change is an oracle-version change)"
+    );
+    assert!(SKPARAGRAPH_ORACLE_VERSION.ends_with(pinned_in_manifest));
+}
+
+#[test]
+fn the_arrival_of_a_font_resource_creates_a_new_environment_identity_and_a_new_resolved_artifact() {
+    let mut ctx = Ctx::new();
+    let before = ctx.resolve("hello", None);
+
+    // Register a new font resource: the environment identity must change and
+    // the next resolution must be a new artifact, never the old one patched.
+    let hash = 0x42_554e_u64;
+    ctx.store
+        .lock()
+        .unwrap()
+        .insert(hash, BUNGEE_REGULAR.to_vec());
+    ctx.fonts.add(hash, "Bungee");
+
+    let after = ctx.resolve("hello", None);
+    assert_ne!(before.environment, after.environment);
+    assert!(
+        !Arc::ptr_eq(&before, &after),
+        "a supposedly immutable result is never patched in place by a late font swap"
+    );
+    assert_eq!(after.environment.font_generation, ctx.fonts.generation());
+}
+
+#[test]
+fn cache_reuse_publishes_the_same_immutable_artifact_for_the_same_identity() {
+    let mut ctx = Ctx::new();
+    let first = ctx.resolve("hello", Some(120.0));
+    let second = ctx.resolve("hello", Some(120.0));
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "internal cache reuse must republish the equivalent artifact for the same identity"
+    );
+
+    // A different constraint produces a different resolution — it is not
+    // another view of the old result.
+    let other = ctx.resolve("hello", Some(60.0));
+    assert!(!Arc::ptr_eq(&first, &other));
+    assert_eq!(other.width_constraint, Some(60.0));
+}
+
+#[test]
+fn paint_only_changes_do_not_invalidate_the_geometry_artifact() {
+    use grida::runtime::image_repository::ImageRepository;
+    let mut ctx = Ctx::new();
+    let images = ImageRepository::new(ctx.store.clone());
+    let before = ctx.resolve("hello", Some(120.0));
+
+    // Build the painted paragraph for the same text (the paint surface).
+    let fills = [Paint::Solid(CGColor::BLACK.into())];
+    let _painted = ctx.cache.paragraph(
+        "hello",
+        &fills,
+        &ctx.align,
+        &ctx.style,
+        &None,
+        &None,
+        Some(120.0),
+        &ctx.fonts,
+        &images,
+        None,
+    );
+
+    let after = ctx.resolve("hello", Some(120.0));
+    assert!(
+        Arc::ptr_eq(&before, &after),
+        "paint state is not a geometry input; painting must not invalidate the artifact"
+    );
+}
+
+#[test]
+fn the_constraint_input_and_the_final_oracle_layout_width_are_retained() {
+    let mut ctx = Ctx::new();
+    let constrained = ctx.resolve("hello world", Some(100.0));
+    assert_eq!(constrained.width_constraint, Some(100.0));
+    assert_eq!(constrained.layout_width, 100.0);
+
+    let unconstrained = ctx.resolve("hello", None);
+    assert_eq!(unconstrained.width_constraint, None);
+    assert_eq!(
+        unconstrained.layout_width, unconstrained.metrics.max_intrinsic_width,
+        "an unconstrained inline axis lays out at the measured intrinsic width"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Measurement as a projection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn measurement_is_a_query_over_the_resolved_artifact_not_a_parallel_text_operation() {
+    let mut ctx = Ctx::new();
+    let text = "h\u{e9}llo\nw\u{f6}rld";
+    let measured = ctx.cache.measure(
+        text, &ctx.style, &ctx.align, &None, &None, None, &ctx.fonts, None,
+    );
+    let artifact = ctx.resolve(text, None);
+    let projected = LayoutMeasurements::from(artifact.as_ref());
+
+    assert_eq!(measured.height, projected.height);
+    assert_eq!(measured.max_width, projected.max_width);
+    assert_eq!(measured.min_intrinsic_width, projected.min_intrinsic_width);
+    assert_eq!(measured.max_intrinsic_width, projected.max_intrinsic_width);
+    assert_eq!(measured.alphabetic_baseline, projected.alphabetic_baseline);
+    assert_eq!(
+        measured.ideographic_baseline,
+        projected.ideographic_baseline
+    );
+    assert_eq!(measured.longest_line, projected.longest_line);
+    assert_eq!(measured.line_number, projected.line_number);
+    assert_eq!(
+        measured.did_exceed_max_lines,
+        projected.did_exceed_max_lines
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Paragraphs and lines
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lines_carry_utf8_byte_ranges_at_scalar_boundaries() {
+    let mut ctx = Ctx::new();
+    // é and ö are two UTF-8 bytes each: byte ranges must be UTF-8, not
+    // UTF-16 code-unit ranges leaked from the oracle.
+    let text = "h\u{e9}llo\nw\u{f6}rld";
+    let artifact = ctx.resolve(text, None);
+
+    assert_eq!(artifact.lines.len(), 2);
+    assert_eq!(
+        artifact.lines[0].source_range,
+        0..7,
+        "line 0 consumes its explicit terminator"
+    );
+    assert_eq!(artifact.lines[1].source_range, 7..13);
+    for line in &artifact.lines {
+        assert!(artifact
+            .shaping_text
+            .is_char_boundary(line.source_range.start));
+        assert!(artifact
+            .shaping_text
+            .is_char_boundary(line.source_range.end));
+        assert_eq!(line.index, artifact.lines[line.index].index);
+    }
+    assert_eq!(artifact.line_at_byte(8), Some(1));
+    assert_eq!(artifact.line_at_byte(13), Some(1));
+}
+
+#[test]
+fn explicit_soft_terminal_and_truncated_line_ends_are_distinguished() {
+    let mut ctx = Ctx::new();
+
+    // Explicit break, then terminal line.
+    let explicit = ctx.resolve("a\nb", None);
+    assert_eq!(explicit.lines.len(), 2);
+    assert_eq!(explicit.lines[0].break_kind, LineBreakKind::Explicit);
+    assert_eq!(explicit.lines[1].break_kind, LineBreakKind::Terminal);
+
+    // Explicit source line breaks are source content, whatever the
+    // terminator: CRLF and LINE SEPARATOR are consumed by the line they end.
+    let crlf = ctx.resolve("a\r\nb", None);
+    assert_eq!(crlf.lines[0].break_kind, LineBreakKind::Explicit);
+    assert_eq!(crlf.lines[0].source_range, 0..3);
+    let ls = ctx.resolve("a\u{2028}b", None);
+    assert_eq!(ls.lines[0].break_kind, LineBreakKind::Explicit);
+    assert_eq!(ls.lines[0].source_range, 0..4);
+
+    // Soft wrap chosen by the oracle, then terminal line.
+    let soft = ctx.resolve("aa bb", Some(30.0));
+    assert_eq!(soft.lines.len(), 2);
+    assert_eq!(soft.lines[0].break_kind, LineBreakKind::Soft);
+    assert_eq!(
+        soft.lines[0].source_range,
+        0..3,
+        "the separator consumed at a soft wrap stays represented in line coverage"
+    );
+    assert_eq!(soft.lines[1].break_kind, LineBreakKind::Terminal);
+
+    // Truncation policy replaced remaining source.
+    let truncated = ctx.resolve_truncated("aaaa bbbb cccc dddd eeee ffff", Some(80.0));
+    assert!(truncated.metrics.did_exceed_max_lines);
+    assert_eq!(
+        truncated.lines.last().unwrap().break_kind,
+        LineBreakKind::Truncated
+    );
+}
+
+#[test]
+fn an_empty_source_resolves_to_one_empty_terminal_line() {
+    let mut ctx = Ctx::new();
+    let artifact = ctx.resolve("", None);
+
+    assert_eq!(artifact.lines.len(), 1);
+    let line = &artifact.lines[0];
+    assert_eq!(line.break_kind, LineBreakKind::Terminal);
+    assert_eq!(line.source_range, 0..0, "no source character is invented");
+    assert!(
+        line.synthesized,
+        "the oracle reports zero lines for empty source; the terminal line is declared synthesized"
+    );
+    assert!(
+        line.baseline > 0.0,
+        "the empty terminal line carries the default style's line metrics"
+    );
+    assert!(artifact.metrics.height > 0.0);
+    assert_eq!(
+        artifact.metrics.line_count, 0,
+        "the oracle's own line count is preserved verbatim"
+    );
+    assert!(artifact.glyph_runs.is_empty());
+    assert!(artifact.clusters.is_empty());
+    assert!(artifact.ink_bounds.is_none());
+}
+
+#[test]
+fn a_source_ending_in_an_explicit_terminator_keeps_an_empty_terminal_line_after_it() {
+    let mut ctx = Ctx::new();
+    let artifact = ctx.resolve("a\n", None);
+
+    assert_eq!(artifact.lines.len(), 2);
+    assert_eq!(artifact.lines[0].break_kind, LineBreakKind::Explicit);
+    assert_eq!(
+        artifact.lines[0].source_range,
+        0..2,
+        "the preceding line ends explicitly and consumes its terminator"
+    );
+    assert_eq!(artifact.lines[1].break_kind, LineBreakKind::Terminal);
+    assert_eq!(artifact.lines[1].source_range, 2..2);
+}
+
+// ---------------------------------------------------------------------------
+// Bounds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn logical_bounds_and_ink_bounds_are_kept_distinct() {
+    let mut ctx = Ctx::new();
+
+    // A line box includes layout space where no ink is drawn: glyph ink for
+    // lowercase latin is strictly shorter than the typographic line box.
+    let artifact = ctx.resolve("aaa", None);
+    let logical = artifact.logical_bounds;
+    let ink = artifact
+        .ink_bounds
+        .expect("visible glyphs must produce base ink");
+    assert!(
+        ink.height < logical.height,
+        "ink height ({}) must stay below the typographic line box height ({})",
+        ink.height,
+        logical.height
+    );
+    assert_ne!(logical, ink);
+    for line in &artifact.lines {
+        assert!(line.ink_bounds.is_some());
+        assert_ne!(Some(line.logical_bounds), line.ink_bounds);
+    }
+
+    // A newline-only source has logical extent but draws nothing.
+    let empty_lines = ctx.resolve("\n", None);
+    assert!(empty_lines.ink_bounds.is_none());
+    assert!(empty_lines.logical_bounds.height > 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// Clusters and UTF-8 mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_visible_glyph_belongs_to_exactly_one_shaped_run_line_and_cluster() {
+    let mut ctx = Ctx::new();
+    let artifact = ctx.resolve("h\u{e9}llo\nw\u{f6}rld", None);
+
+    assert!(!artifact.glyph_runs.is_empty());
+    for (run_index, run) in artifact.glyph_runs.iter().enumerate() {
+        assert!(run.line < artifact.lines.len());
+        assert_eq!(run.glyph_ids.len(), run.positions.len());
+        let starts = run
+            .cluster_starts
+            .as_ref()
+            .expect("non-synthetic runs carry cluster mappings");
+        assert_eq!(starts.len(), run.glyph_ids.len());
+        for glyph_index in 0..run.glyph_ids.len() {
+            let owners: Vec<_> = artifact
+                .clusters
+                .iter()
+                .filter(|c| {
+                    c.glyph_span
+                        .as_ref()
+                        .is_some_and(|(r, g)| *r == run_index && g.contains(&glyph_index))
+                })
+                .collect();
+            assert_eq!(
+                owners.len(),
+                1,
+                "glyph {glyph_index} of run {run_index} must belong to exactly one cluster"
+            );
+            assert_eq!(owners[0].line, run.line);
+        }
+    }
+}
+
+#[test]
+fn non_synthetic_clusters_cover_the_shaping_text_without_gaps_or_overlap() {
+    let mut ctx = Ctx::new();
+    for (text, width) in [
+        ("h\u{e9}llo\nw\u{f6}rld", None),
+        ("aa bb", Some(30.0)),
+        ("a\n", None),
+        ("xe\u{301}y z", None),
+    ] {
+        let artifact = ctx.resolve(text, width);
+        assert!(
+            artifact.unmapped_ranges.is_empty(),
+            "{text:?}: the oracle mapped all consumed source; nothing may remain implicit"
+        );
+        let mut cursor = 0usize;
+        for cluster in &artifact.clusters {
+            assert_eq!(
+                cluster.range.start, cursor,
+                "{text:?}: clusters must be contiguous without gaps or overlap at byte {cursor}"
+            );
+            assert!(cluster.range.end > cluster.range.start);
+            cursor = cluster.range.end;
+        }
+        assert_eq!(
+            cursor,
+            text.len(),
+            "{text:?}: clusters must cover the complete shaping text"
+        );
+
+        // Advance boxes of a run's clusters partition the run's advance
+        // extent (cluster advance is real geometry, not an estimate).
+        for (run_index, run) in artifact.glyph_runs.iter().enumerate() {
+            let total: f32 = artifact
+                .clusters
+                .iter()
+                .filter(|c| c.glyph_span.as_ref().is_some_and(|(r, _)| *r == run_index))
+                .map(|c| c.advance_bounds.width)
+                .sum();
+            assert!(
+                (total - run.advance_width).abs() < 0.05,
+                "{text:?}: cluster advance boxes ({total}) must partition run advance ({})",
+                run.advance_width
+            );
+        }
+    }
+}
+
+#[test]
+fn grapheme_cluster_shaping_cluster_glyph_and_caret_stop_index_spaces_are_not_collapsed() {
+    let mut ctx = Ctx::new();
+
+    // Ligature: two graphemes ("f", "f") resolve into one shaping cluster
+    // with one glyph. The cluster spans bytes 0..2; byte 1 is a grapheme
+    // boundary but not a cluster boundary.
+    let ligature = ctx.resolve("ffi", None);
+    let first = &ligature.clusters[0];
+    assert_eq!(first.range, 0..2, "Geist ligates the ff pair");
+    let (run, glyphs) = first.glyph_span.clone().expect("visible cluster");
+    assert_eq!(glyphs.len(), 1, "one ligature glyph for two graphemes");
+    assert_eq!(run, 0);
+    assert!(
+        !ligature.clusters.iter().any(|c| c.range.start == 1),
+        "a grapheme boundary inside a ligature is not a shaping-cluster boundary"
+    );
+
+    // Combining sequence: one grapheme ("e" + U+0301) spanning three bytes
+    // forms one cluster; interior scalar boundaries are not cluster starts.
+    let combining = ctx.resolve("xe\u{301}y", None);
+    assert!(
+        combining.clusters.iter().any(|c| c.range == (1..4)),
+        "the combining sequence must resolve to one cluster covering bytes 1..4"
+    );
+}
+
+#[test]
+fn within_a_line_visual_glyph_order_may_differ_from_logical_source_order() {
+    let mut ctx = Ctx::with_hebrew_fallback();
+    // "ab שלום cd" — Hebrew word bytes 3..11, two Hebrew-letter clusters of
+    // two bytes each.
+    let text = "ab \u{5e9}\u{5dc}\u{5d5}\u{5dd} cd";
+    let artifact = ctx.resolve(text, None);
+    assert_eq!(
+        artifact.unresolved_glyphs,
+        Some(0),
+        "the fixture font must cover the Hebrew"
+    );
+
+    let rtl: Vec<_> = artifact
+        .clusters
+        .iter()
+        .filter(|c| c.direction == ResolvedDirection::Rtl)
+        .collect();
+    let ranges: Vec<_> = rtl.iter().map(|c| c.range.clone()).collect();
+    assert_eq!(ranges, vec![3..5, 5..7, 7..9, 9..11]);
+
+    // Logical order ascends; visual x positions descend: the first Hebrew
+    // letter (bytes 3..5) sits visually right of the last (bytes 9..11).
+    let first_logical = rtl.iter().find(|c| c.range == (3..5)).unwrap();
+    let last_logical = rtl.iter().find(|c| c.range == (9..11)).unwrap();
+    assert!(
+        first_logical.advance_bounds.x > last_logical.advance_bounds.x,
+        "visual order differs from logical order in a bidirectional line"
+    );
+
+    // The run that shaped the Hebrew records the exact resolved fallback
+    // face, not the requested family.
+    let hebrew_run = artifact
+        .glyph_runs
+        .iter()
+        .find(|r| r.font.family == "Noto Sans Hebrew")
+        .expect("fallback resolution must be recorded per run");
+    assert!(!hebrew_run.glyph_ids.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Truncation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn truncation_marker_is_synthetic_and_never_masquerades_as_authored_content() {
+    let mut ctx = Ctx::new();
+    let text = "aaaa bbbb cccc dddd eeee ffff";
+    let artifact = ctx.resolve_truncated(text, Some(80.0));
+
+    assert!(artifact.metrics.did_exceed_max_lines);
+    let marker = artifact
+        .glyph_runs
+        .iter()
+        .find(|r| r.synthetic)
+        .expect("truncation must record a synthetic marker run");
+    assert!(
+        marker.cluster_starts.is_none(),
+        "a synthetic unit must never claim authored source coverage"
+    );
+    assert!(
+        !marker.glyph_ids.is_empty(),
+        "the marker's shaped glyphs are recorded"
+    );
+    assert_eq!(
+        artifact.glyph_runs.iter().filter(|r| r.synthetic).count(),
+        1
+    );
+
+    // Every omitted source byte is declared, anchored after the consumed
+    // prefix; visible clusters never reach into the omission.
+    let omitted = artifact
+        .omitted_by_truncation
+        .clone()
+        .expect("truncation must declare the omitted source range");
+    assert_eq!(omitted.end, text.len());
+    assert_eq!(
+        omitted.start,
+        artifact.lines.last().unwrap().source_range.end
+    );
+    for cluster in &artifact.clusters {
+        assert!(cluster.range.end <= omitted.start);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Declared gaps (asserted absences — never fabricated values)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn caret_stops_are_a_declared_absence_under_this_oracle() {
+    // RFD: a caret stop is not assumed to exist at every UTF-8 or glyph
+    // boundary. Skia does not enumerate legal caret stops with affinity, so
+    // the artifact declares the absence instead of estimating positions
+    // (declared gap 1 in `text::resolved`).
+    let mut ctx = Ctx::new();
+    let artifact = ctx.resolve("hello world", None);
+    assert!(artifact.caret_stops.is_none());
+}
+
+#[test]
+fn per_glyph_advances_are_a_declared_absence_under_this_oracle() {
+    // Skia's visitor exposes positions and run advances only (declared gap
+    // 5); per-glyph advances are never inferred from position deltas.
+    let mut ctx = Ctx::new();
+    let artifact = ctx.resolve("hello world", None);
+    assert!(!artifact.glyph_runs.is_empty());
+    for run in &artifact.glyph_runs {
+        assert!(run.glyph_advances.is_none());
+    }
+}
+
+#[test]
+fn a_transformed_shaping_text_declares_its_transformation_policy_not_a_source_mapping() {
+    // RFD: a source transformation is an explicit input and the result
+    // retains a mapping back to source. Skia never sees the authored source
+    // (declared gap 2), so the artifact records the policy and the derived
+    // shaping text — and declares that its byte coordinates are not source
+    // coordinates — rather than fabricating a mapping.
+    let mut ctx = Ctx::new();
+    ctx.style.text_transform = TextTransform::Uppercase;
+    let artifact = ctx.resolve("\u{df} and co", None); // ß → SS changes byte length
+    assert_eq!(
+        artifact.transform,
+        ShapingTransform::Uniform(TextTransform::Uppercase)
+    );
+    assert!(!artifact.transform.is_identity());
+    assert_eq!(artifact.shaping_text, "SS AND CO");
+    assert_ne!(
+        artifact.shaping_text.chars().count(),
+        "\u{df} and co".chars().count(),
+        "\u{df} \u{2192} SS changes the scalar count: byte coordinates cannot be source coordinates"
+    );
+
+    // Identity is declared when no transformation runs.
+    let mut plain = Ctx::new();
+    let identity = plain.resolve("hello", None);
+    assert!(identity.transform.is_identity());
+}
+
+#[test]
+fn unresolved_glyph_coverage_is_reported_never_silent() {
+    // Strict RFD resolution fails on missing glyph coverage; this engine's
+    // environment explicitly permits tofu, so the artifact must report the
+    // unresolved count instead of presenting tofu as resolved coverage.
+    let mut ctx = Ctx::new(); // embedded Geist only: no Hebrew coverage
+    let artifact = ctx.resolve("ab \u{5e9}\u{5dc}\u{5d5}\u{5dd}", None);
+    let unresolved = artifact
+        .unresolved_glyphs
+        .expect("the oracle reports an unresolved-glyph count");
+    assert!(
+        unresolved > 0,
+        "missing coverage must be reported, not silently dropped"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Coordinates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fractional_logical_geometry_is_preserved_without_device_rounding() {
+    let mut ctx = Ctx::new();
+    let artifact = ctx.resolve("h\u{e9}llo", None);
+    let has_fractional_position = artifact
+        .glyph_runs
+        .iter()
+        .flat_map(|r| r.positions.iter())
+        .any(|p| p[0].fract() != 0.0);
+    let has_fractional_metric = artifact.metrics.max_intrinsic_width.fract() != 0.0
+        || artifact.lines.iter().any(|l| l.width.fract() != 0.0);
+    assert!(
+        has_fractional_position || has_fractional_metric,
+        "fractional advances and offsets must be preserved in logical units"
+    );
+}


### PR DESCRIPTION
The design-track seam of the **legacy seam program** (#27); implements and closes #32.

## What

`ResolvedTextLayout` (`crates/grida/src/text/resolved.rs`) — an immutable, backend-neutral resolved-text-layout artifact produced at the paragraph-cache choke point, conformant to the Universal Shaped Text Layout RFD (lands with #26; this PR should merge after it):

- **Resolution identity**: oracle version `skparagraph@skia-0.93.1` (derived from one pinned literal; a conformance test asserts lockstep with the actual `skia-safe` pin in Cargo.toml) + environment identity from the FontRepository generation the cache already keys invalidation on
- **Geometry, never paint**: paragraph metrics, lines (UTF-8 ranges, break kinds, per-line logical/ink bounds), glyph runs (resolved post-fallback font identity, positions, per-glyph ink), and the shaping-cluster ledger — grapheme/cluster/glyph/caret index spaces kept distinct per the RFD
- **The anti-goal in the module header, day one**: not a private retained IR — derived, immutable, rebuilt from inputs, never serialized into `.grida`
- **First consumer**: `measure()`/`measure_attributed()` are now projections over the artifact (`LayoutMeasurements: From<&ResolvedTextLayout>`) — the layout engine consumes artifact-backed numbers with numerically identical results. Painting keeps the cached Skia `Paragraph`, untouched. Hit-test/text_edit/export migrate at their own pace (the seam is proven by the first consumer + the tests).

## The honesty core: 8 declared RFD gaps

Where Skia Paragraph cannot supply what the RFD demands, the artifact declares the absence instead of fabricating — each gap documented in the module header with its forcing limitation, several asserted as declared absences by tests: caret stops (no enumerable API), source mapping under text transforms (ß→SS rewrites before shaping), exact font-content identity (no typeface digest), process-local environment identity, per-glyph advances, truncation-marker source aliasing (probed: the ellipsis run aliases authored byte offsets — its mapping is withheld so it never masquerades as authored content), omission ranges, and the assigned text box (lives above this layer). Two guarded normalizations of degenerate oracle outputs (empty-source terminal line; trailing-terminator index repair) are documented with their guards; a probe also corrected the hard-terminator set (NEL/LS/PS in, bare CR out).

## Gates (all green, nothing blessed)

- 32/32 suites ok incl. the new **22-test conformance suite named from the RFD's scenario vocabulary**; clippy + `cargo check --workspace` clean
- **L0.exact: byte-identical** to the M0 baseline (#27) · **iosvg reftest, 1679 fixtures: byte-identical**
- `format/grida.fbs` and the wasm surface untouched