### PR TITLE
refactor(import/html): one front-end, one style record — the importer seam

### DIFF
--- a/crates/grida/src/htmlcss/collect.rs
+++ b/crates/grida/src/htmlcss/collect.rs
@@ -2179,17 +2179,19 @@ fn gradient_items_to_stops(
 ) -> Vec<GradientStop> {
     use style::values::generics::image::GenericGradientItem;
 
-    let resolve = |color: &style::values::computed::Color| -> CGColor {
-        color
-            .as_absolute()
-            .map(abs_color_to_cg)
-            .unwrap_or(current_color)
+    // Resolve to (color, was_currentcolor) — `as_absolute()` is `None`
+    // exactly when the stop is an unresolved `currentcolor`.
+    let resolve = |color: &style::values::computed::Color| -> (CGColor, bool) {
+        match color.as_absolute() {
+            Some(abs) => (abs_color_to_cg(abs), false),
+            None => (current_color, true),
+        }
     };
 
-    // Each element: (position, is_px, color). Px-positioned stops are
-    // normalized to gradient-line fractions at paint time where the line
-    // length is known.
-    let mut raw: Vec<(Option<f32>, bool, CGColor)> = Vec::new();
+    // Each element: (position, is_px, (color, is_currentcolor)).
+    // Px-positioned stops are normalized to gradient-line fractions at
+    // paint time where the line length is known.
+    let mut raw: Vec<(Option<f32>, bool, (CGColor, bool))> = Vec::new();
     for item in items {
         match item {
             GenericGradientItem::SimpleColorStop(color) => {
@@ -2210,10 +2212,11 @@ fn gradient_items_to_stops(
     }
     auto_distribute_stops_typed(&mut raw);
     raw.into_iter()
-        .map(|(o, is_px, c)| GradientStop {
+        .map(|(o, is_px, (c, is_cc))| GradientStop {
             offset: o.unwrap_or(0.0),
             offset_is_px: is_px,
             color: c,
+            color_is_currentcolor: is_cc,
         })
         .collect()
 }
@@ -2224,7 +2227,7 @@ fn gradient_items_to_stops(
 /// runs of auto stops are linearly interpolated between their bookends. When
 /// bookends use different units we inherit the previous stop's unit; exact
 /// resolution defers to paint-time which has the gradient-line length.
-fn auto_distribute_stops_typed(raw: &mut [(Option<f32>, bool, CGColor)]) {
+fn auto_distribute_stops_typed(raw: &mut [(Option<f32>, bool, (CGColor, bool))]) {
     let n = raw.len();
     if n == 0 {
         return;
@@ -2292,14 +2295,15 @@ fn conic_gradient_items_to_stops(
     use style::values::computed::AngleOrPercentage;
     use style::values::generics::image::GenericGradientItem;
 
-    let resolve = |color: &style::values::computed::Color| -> CGColor {
-        color
-            .as_absolute()
-            .map(abs_color_to_cg)
-            .unwrap_or(current_color)
+    // See `gradient_items_to_stops` — (color, was_currentcolor).
+    let resolve = |color: &style::values::computed::Color| -> (CGColor, bool) {
+        match color.as_absolute() {
+            Some(abs) => (abs_color_to_cg(abs), false),
+            None => (current_color, true),
+        }
     };
 
-    let mut raw: Vec<(Option<f32>, CGColor)> = Vec::new();
+    let mut raw: Vec<(Option<f32>, (CGColor, bool))> = Vec::new();
     for item in items {
         match item {
             GenericGradientItem::SimpleColorStop(color) => {
@@ -2317,16 +2321,17 @@ fn conic_gradient_items_to_stops(
     }
     auto_distribute_stops(&mut raw);
     raw.into_iter()
-        .map(|(o, c)| GradientStop {
+        .map(|(o, (c, is_cc))| GradientStop {
             offset: o.unwrap_or(0.0),
             offset_is_px: false,
             color: c,
+            color_is_currentcolor: is_cc,
         })
         .collect()
 }
 
 /// Auto-distribute gradient stop offsets (first=0, last=1, gaps interpolated).
-fn auto_distribute_stops(raw: &mut [(Option<f32>, CGColor)]) {
+fn auto_distribute_stops(raw: &mut [(Option<f32>, (CGColor, bool))]) {
     let n = raw.len();
     if n == 0 {
         return;
@@ -2766,6 +2771,17 @@ fn extract_font(style: &ComputedValues, current_color: CGColor) -> FontProps {
         TextAlignKeyword::Right | TextAlignKeyword::MozRight => TextAlign::Right,
         TextAlignKeyword::Center | TextAlignKeyword::MozCenter => TextAlign::Center,
         TextAlignKeyword::Justify => TextAlign::Justify,
+    };
+    // Keyword identity, pre-resolution — the direction resolution above
+    // is lossy (an RTL `start` and an authored `right` both land on
+    // `TextAlign::Right`); the HTML importer needs the keyword itself.
+    props.text_align_keyword = match inherited_text.text_align {
+        TextAlignKeyword::Start => types::TextAlignKeyword::Start,
+        TextAlignKeyword::End => types::TextAlignKeyword::End,
+        TextAlignKeyword::Left | TextAlignKeyword::MozLeft => types::TextAlignKeyword::Left,
+        TextAlignKeyword::Right | TextAlignKeyword::MozRight => types::TextAlignKeyword::Right,
+        TextAlignKeyword::Center | TextAlignKeyword::MozCenter => types::TextAlignKeyword::Center,
+        TextAlignKeyword::Justify => types::TextAlignKeyword::Justify,
     };
 
     // Text transform

--- a/crates/grida/src/htmlcss/collect.rs
+++ b/crates/grida/src/htmlcss/collect.rs
@@ -227,6 +227,28 @@ fn collect_element(element: HtmlElement) -> StyledElement {
     collect_element_with_counter(element, &mut None)
 }
 
+/// Extract the resolved style record for ONE element — the per-element
+/// seam the HTML importer consumes (gridaco/nothing#30).
+///
+/// This mirrors exactly the prefix of [`collect_element_with_counter`]
+/// that obtains the element's primary `ComputedValues`, then runs the
+/// shared [`extract_style`] — and nothing else. Deliberately **not**
+/// routed through the tree-shaping collect path: no inline-group
+/// merging, no list counters, no widget synthesis, no root-margin
+/// stripping, and no recursion into children. Returns `None` when the
+/// element has no style data (the importer skips such elements, where
+/// the renderer path panics).
+///
+/// Colors are quantized with [`ColorQuantize::Truncate`] — the
+/// importer's pinned golden behavior; see [`ColorQuantize`].
+pub(crate) fn styled_of(element: HtmlElement) -> Option<StyledElement> {
+    let tag = element.local_name_string();
+    let data = element.borrow_data();
+    let style = data.as_ref().map(|d| d.styles.primary().clone())?;
+    drop(data);
+    Some(extract_style(&tag, &style, ColorQuantize::Truncate))
+}
+
 fn collect_element_with_counter(
     element: HtmlElement,
     list_counter: &mut Option<ListCounter>,
@@ -239,7 +261,7 @@ fn collect_element_with_counter(
         .map(|d| d.styles.primary().clone())
         .unwrap_or_else(|| panic!("Element {tag} has no style data"));
 
-    let mut el = extract_style(&tag, &style);
+    let mut el = extract_style(&tag, &style, ColorQuantize::Round);
 
     // Strip root element margins
     if tag == "html" || tag == "body" {
@@ -1143,7 +1165,7 @@ fn flush_inline_group(
 
 // ─── CSS property extraction ─────────────────────────────────────────
 
-fn extract_style(tag: &str, style: &ComputedValues) -> StyledElement {
+fn extract_style(tag: &str, style: &ComputedValues, q: ColorQuantize) -> StyledElement {
     let mut el = StyledElement {
         tag: tag.to_string(),
         ..StyledElement::default()
@@ -1231,19 +1253,19 @@ fn extract_style(tag: &str, style: &ComputedValues) -> StyledElement {
 
     // Text color (inherited) — must be resolved before any
     // `currentcolor`-aware extraction (background gradients, border image).
-    el.color = abs_color_to_cg(&style.get_inherited_text().color);
+    el.color = q.abs_to_cg(&style.get_inherited_text().color);
 
     // Border
-    el.border = extract_border(style, el.color);
+    el.border = extract_border(style, el.color, q);
 
     // Border image (9-slice)
-    el.border_image = extract_border_image(style, el.color);
+    el.border_image = extract_border_image(style, el.color, q);
 
     // Border radius
     el.border_radius = extract_border_radius(style);
 
     // Outline (does not affect layout — paint-only)
-    el.outline = extract_outline(style);
+    el.outline = extract_outline(style, q);
 
     // Dimensions
     let pos = style.get_position();
@@ -1284,15 +1306,15 @@ fn extract_style(tag: &str, style: &ComputedValues) -> StyledElement {
     }
 
     // Background
-    el.background = extract_background(style, el.color);
+    el.background = extract_background(style, el.color, q);
 
     // Font properties (inherited)
-    el.font = extract_font(style, el.color);
+    el.font = extract_font(style, el.color, q);
 
     // Box shadow
-    el.box_shadow = extract_box_shadow(style, el.color);
-    el.filter = extract_filter(style, el.color);
-    el.backdrop_filter = extract_backdrop_filter(style, el.color);
+    el.box_shadow = extract_box_shadow(style, el.color, q);
+    el.filter = extract_filter(style, el.color, q);
+    el.backdrop_filter = extract_backdrop_filter(style, el.color, q);
     el.clip_path = extract_clip_path(style);
 
     // Transform
@@ -1463,7 +1485,7 @@ fn map_border_style(bs: style::values::specified::border::BorderStyle) -> types:
     }
 }
 
-fn extract_border(style: &ComputedValues, current_color: CGColor) -> BorderBox {
+fn extract_border(style: &ComputedValues, current_color: CGColor, q: ColorQuantize) -> BorderBox {
     let b = style.get_border();
 
     // `border-*-color` defaults to `currentcolor`, which Stylo leaves
@@ -1473,7 +1495,7 @@ fn extract_border(style: &ComputedValues, current_color: CGColor) -> BorderBox {
     let extract_color = |color: &style::values::computed::Color| -> CGColor {
         color
             .as_absolute()
-            .map(abs_color_to_cg)
+            .map(|abs| q.abs_to_cg(abs))
             .unwrap_or(current_color)
     };
 
@@ -1520,10 +1542,14 @@ fn side_width(
 /// Returns `Some(BorderImage)` when `border-image-source` is set to a
 /// non-none value. The source image URL is extracted the same way as
 /// `background-image: url()` — via `GenericImage::Url` / `ComputedUrl`.
-fn extract_border_image(style: &ComputedValues, current_color: CGColor) -> Option<BorderImage> {
+fn extract_border_image(
+    style: &ComputedValues,
+    current_color: CGColor,
+    q: ColorQuantize,
+) -> Option<BorderImage> {
     let b = style.get_border();
 
-    let source = convert_image(&b.border_image_source, current_color)?;
+    let source = convert_image(&b.border_image_source, current_color, q)?;
 
     // border-image-slice: BorderImageSlice { offsets: Rect<NonNegative<NumberOrPercentage>>, fill }
     let slice_computed = &b.border_image_slice;
@@ -1622,7 +1648,7 @@ fn extract_border_image(style: &ComputedValues, current_color: CGColor) -> Optio
 ///
 /// Chromium: `ComputedStyle::OutlineWidth()`, `OutlineColor()`,
 /// `OutlineStyle()`, `OutlineOffset()`.
-fn extract_outline(style: &ComputedValues) -> Outline {
+fn extract_outline(style: &ComputedValues, q: ColorQuantize) -> Outline {
     let o = style.get_outline();
 
     // outline-style: Auto | BorderStyle(bs)
@@ -1647,8 +1673,8 @@ fn extract_outline(style: &ComputedValues) -> Outline {
     let color = o
         .outline_color
         .as_absolute()
-        .map(abs_color_to_cg)
-        .unwrap_or_else(|| abs_color_to_cg(&style.get_inherited_text().color));
+        .map(|abs| q.abs_to_cg(abs))
+        .unwrap_or_else(|| q.abs_to_cg(&style.get_inherited_text().color));
 
     Outline {
         width,
@@ -1665,6 +1691,7 @@ fn extract_outline(style: &ComputedValues) -> Outline {
 fn convert_image(
     image: &style::values::computed::Image,
     current_color: CGColor,
+    q: ColorQuantize,
 ) -> Option<StyleImage> {
     use style::values::computed::url::ComputedUrl;
     use style::values::generics::image::{GenericGradient, GenericImage};
@@ -1690,7 +1717,7 @@ fn convert_image(
                 color_interpolation_method,
                 ..
             } => {
-                let stops = gradient_items_to_stops(items, current_color);
+                let stops = gradient_items_to_stops(items, current_color, q);
                 if stops.is_empty() {
                     return None;
                 }
@@ -1711,7 +1738,7 @@ fn convert_image(
                 color_interpolation_method,
                 ..
             } => {
-                let stops = gradient_items_to_stops(items, current_color);
+                let stops = gradient_items_to_stops(items, current_color, q);
                 if stops.is_empty() {
                     return None;
                 }
@@ -1733,7 +1760,7 @@ fn convert_image(
                 color_interpolation_method,
                 ..
             } => {
-                let stops = conic_gradient_items_to_stops(items, current_color);
+                let stops = conic_gradient_items_to_stops(items, current_color, q);
                 if stops.is_empty() {
                     return None;
                 }
@@ -1874,7 +1901,11 @@ fn extract_inset(style: &ComputedValues) -> CssEdgeInsets {
     }
 }
 
-fn extract_background(style: &ComputedValues, current_color: CGColor) -> Vec<BackgroundLayer> {
+fn extract_background(
+    style: &ComputedValues,
+    current_color: CGColor,
+    q: ColorQuantize,
+) -> Vec<BackgroundLayer> {
     let bg = style.get_background();
     let mut layers: Vec<BackgroundLayer> = Vec::new();
 
@@ -1882,7 +1913,7 @@ fn extract_background(style: &ComputedValues, current_color: CGColor) -> Vec<Bac
     //    color uses the `background-clip` value from the *final* layer
     //    entry in the list.
     if let Some(abs) = bg.background_color.as_absolute() {
-        let c = abs_color_to_cg(abs);
+        let c = q.abs_to_cg(abs);
         if c.a > 0 {
             let color_clip = bg
                 .background_clip
@@ -1918,7 +1949,7 @@ fn extract_background(style: &ComputedValues, current_color: CGColor) -> Vec<Bac
     let origins = &bg.background_origin.0;
 
     for (i, image) in bg.background_image.0.iter().enumerate().rev() {
-        let Some(source) = convert_image(image, current_color) else {
+        let Some(source) = convert_image(image, current_color, q) else {
             continue;
         };
         let size = sizes
@@ -2176,6 +2207,7 @@ fn gradient_items_to_stops(
         style::values::computed::LengthPercentage,
     >],
     current_color: CGColor,
+    q: ColorQuantize,
 ) -> Vec<GradientStop> {
     use style::values::generics::image::GenericGradientItem;
 
@@ -2183,7 +2215,7 @@ fn gradient_items_to_stops(
     // exactly when the stop is an unresolved `currentcolor`.
     let resolve = |color: &style::values::computed::Color| -> (CGColor, bool) {
         match color.as_absolute() {
-            Some(abs) => (abs_color_to_cg(abs), false),
+            Some(abs) => (q.abs_to_cg(abs), false),
             None => (current_color, true),
         }
     };
@@ -2291,6 +2323,7 @@ fn conic_gradient_items_to_stops(
         style::values::computed::AngleOrPercentage,
     >],
     current_color: CGColor,
+    q: ColorQuantize,
 ) -> Vec<GradientStop> {
     use style::values::computed::AngleOrPercentage;
     use style::values::generics::image::GenericGradientItem;
@@ -2298,7 +2331,7 @@ fn conic_gradient_items_to_stops(
     // See `gradient_items_to_stops` — (color, was_currentcolor).
     let resolve = |color: &style::values::computed::Color| -> (CGColor, bool) {
         match color.as_absolute() {
-            Some(abs) => (abs_color_to_cg(abs), false),
+            Some(abs) => (q.abs_to_cg(abs), false),
             None => (current_color, true),
         }
     };
@@ -2365,7 +2398,11 @@ fn auto_distribute_stops(raw: &mut [(Option<f32>, (CGColor, bool))]) {
     }
 }
 
-fn extract_box_shadow(style: &ComputedValues, current_color: CGColor) -> Vec<BoxShadow> {
+fn extract_box_shadow(
+    style: &ComputedValues,
+    current_color: CGColor,
+    q: ColorQuantize,
+) -> Vec<BoxShadow> {
     let shadows = style.clone_box_shadow();
     shadows
         .0
@@ -2377,7 +2414,7 @@ fn extract_box_shadow(style: &ComputedValues, current_color: CGColor) -> Vec<Box
                 .base
                 .color
                 .as_absolute()
-                .map(abs_color_to_cg)
+                .map(|abs| q.abs_to_cg(abs))
                 .unwrap_or(current_color);
             BoxShadow {
                 offset_x: s.base.horizontal.px(),
@@ -2506,20 +2543,29 @@ fn extract_inset_corner_radii(
     }
 }
 
-fn extract_filter(style: &ComputedValues, current_color: CGColor) -> Vec<FilterFunction> {
-    filter_list_to_functions(&style.clone_filter().0, current_color)
+fn extract_filter(
+    style: &ComputedValues,
+    current_color: CGColor,
+    q: ColorQuantize,
+) -> Vec<FilterFunction> {
+    filter_list_to_functions(&style.clone_filter().0, current_color, q)
 }
 
 /// `backdrop-filter` — same value grammar as `filter`. htmlcss paint
 /// does not consume it; carried on the style record for the HTML
 /// importer.
-fn extract_backdrop_filter(style: &ComputedValues, current_color: CGColor) -> Vec<FilterFunction> {
-    filter_list_to_functions(&style.clone_backdrop_filter().0, current_color)
+fn extract_backdrop_filter(
+    style: &ComputedValues,
+    current_color: CGColor,
+    q: ColorQuantize,
+) -> Vec<FilterFunction> {
+    filter_list_to_functions(&style.clone_backdrop_filter().0, current_color, q)
 }
 
 fn filter_list_to_functions(
     filters: &[style::values::computed::Filter],
     current_color: CGColor,
+    q: ColorQuantize,
 ) -> Vec<FilterFunction> {
     use style::values::generics::effects::GenericFilter;
     filters
@@ -2540,7 +2586,7 @@ fn filter_list_to_functions(
                 let color = s
                     .color
                     .as_absolute()
-                    .map(abs_color_to_cg)
+                    .map(|abs| q.abs_to_cg(abs))
                     .unwrap_or(current_color);
                 Some(FilterFunction::DropShadow {
                     offset_x: s.horizontal.px(),
@@ -2678,7 +2724,7 @@ fn extract_grid_placement(
     types::GridPlacement::Auto
 }
 
-fn extract_font(style: &ComputedValues, current_color: CGColor) -> FontProps {
+fn extract_font(style: &ComputedValues, current_color: CGColor, q: ColorQuantize) -> FontProps {
     let font = style.get_font();
     let inherited_text = style.get_inherited_text();
 
@@ -2823,7 +2869,7 @@ fn extract_font(style: &ComputedValues, current_color: CGColor) -> FontProps {
     props.decoration_color = style
         .clone_text_decoration_color()
         .as_absolute()
-        .map(abs_color_to_cg);
+        .map(|abs| q.abs_to_cg(abs));
 
     // text-shadow: inherited list. Stylo gives us resolved absolute colors
     // (falling back to currentcolor resolved against text color).
@@ -2837,7 +2883,7 @@ fn extract_font(style: &ComputedValues, current_color: CGColor) -> FontProps {
             let color = s
                 .color
                 .as_absolute()
-                .map(abs_color_to_cg)
+                .map(|abs| q.abs_to_cg(abs))
                 .unwrap_or(current_color);
             TextShadow {
                 offset_x: s.horizontal.px(),
@@ -3103,14 +3149,41 @@ fn map_overflow(ov: style::values::specified::box_::Overflow) -> types::Overflow
     }
 }
 
-fn abs_color_to_cg(color: &AbsoluteColor) -> CGColor {
-    let srgb = color.to_color_space(ColorSpace::Srgb);
-    CGColor::from_rgba(
-        (srgb.components.0.clamp(0.0, 1.0) * 255.0).round() as u8,
-        (srgb.components.1.clamp(0.0, 1.0) * 255.0).round() as u8,
-        (srgb.components.2.clamp(0.0, 1.0) * 255.0).round() as u8,
-        (srgb.alpha.clamp(0.0, 1.0) * 255.0).round() as u8,
-    )
+/// u8 quantization policy for sRGB → [`CGColor`] conversion — the one
+/// caller-scoped fidelity knob on the shared extraction, like the
+/// `layout.grid.enabled` pref that stays renderer-side in
+/// [`collect_styled_tree`].
+///
+/// The renderer rounds (Chromium-aligned; 614229bf). The HTML importer
+/// truncates, and its golden corpus pins that: `rgb(51 102 204 / 0.5)`
+/// must stay `a: 127` while `#3366cc80` stays `a: 128` — only
+/// truncation distinguishes them. Each caller keeps its policy so both
+/// outputs stay bit-for-bit what they were before the share.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ColorQuantize {
+    /// Round to nearest — htmlcss rendering.
+    Round,
+    /// Truncate toward zero — the HTML importer's pinned behavior.
+    Truncate,
+}
+
+impl ColorQuantize {
+    fn abs_to_cg(self, color: &AbsoluteColor) -> CGColor {
+        let srgb = color.to_color_space(ColorSpace::Srgb);
+        let q = |v: f32| -> u8 {
+            let scaled = v.clamp(0.0, 1.0) * 255.0;
+            match self {
+                ColorQuantize::Round => scaled.round() as u8,
+                ColorQuantize::Truncate => scaled as u8,
+            }
+        };
+        CGColor::from_rgba(
+            q(srgb.components.0),
+            q(srgb.components.1),
+            q(srgb.components.2),
+            q(srgb.alpha),
+        )
+    }
 }
 
 fn process_whitespace(text: &str, ws: WhiteSpace) -> String {

--- a/crates/grida/src/htmlcss/collect.rs
+++ b/crates/grida/src/htmlcss/collect.rs
@@ -1491,33 +1491,43 @@ fn extract_border(style: &ComputedValues, current_color: CGColor, q: ColorQuanti
     // `border-*-color` defaults to `currentcolor`, which Stylo leaves
     // unresolved to absolute. Fall back to the element's computed text
     // color so `border: solid` on red text draws a red border, not an
-    // unexpected opaque black one.
-    let extract_color = |color: &style::values::computed::Color| -> CGColor {
-        color
-            .as_absolute()
-            .map(|abs| q.abs_to_cg(abs))
-            .unwrap_or(current_color)
+    // unexpected opaque black one. The second tuple element records
+    // that the fallback fired — see `BorderSide::color_is_currentcolor`.
+    let extract_color = |color: &style::values::computed::Color| -> (CGColor, bool) {
+        match color.as_absolute() {
+            Some(abs) => (q.abs_to_cg(abs), false),
+            None => (current_color, true),
+        }
     };
+
+    let (top_color, top_cc) = extract_color(&style.clone_border_top_color());
+    let (right_color, right_cc) = extract_color(&style.clone_border_right_color());
+    let (bottom_color, bottom_cc) = extract_color(&style.clone_border_bottom_color());
+    let (left_color, left_cc) = extract_color(&style.clone_border_left_color());
 
     BorderBox {
         top: BorderSide {
             width: side_width(&b.border_top_width, b.border_top_style),
-            color: extract_color(&style.clone_border_top_color()),
+            color: top_color,
+            color_is_currentcolor: top_cc,
             style: map_border_style(b.border_top_style),
         },
         right: BorderSide {
             width: side_width(&b.border_right_width, b.border_right_style),
-            color: extract_color(&style.clone_border_right_color()),
+            color: right_color,
+            color_is_currentcolor: right_cc,
             style: map_border_style(b.border_right_style),
         },
         bottom: BorderSide {
             width: side_width(&b.border_bottom_width, b.border_bottom_style),
-            color: extract_color(&style.clone_border_bottom_color()),
+            color: bottom_color,
+            color_is_currentcolor: bottom_cc,
             style: map_border_style(b.border_bottom_style),
         },
         left: BorderSide {
             width: side_width(&b.border_left_width, b.border_left_style),
-            color: extract_color(&style.clone_border_left_color()),
+            color: left_color,
+            color_is_currentcolor: left_cc,
             style: map_border_style(b.border_left_style),
         },
     }

--- a/crates/grida/src/htmlcss/collect.rs
+++ b/crates/grida/src/htmlcss/collect.rs
@@ -28,25 +28,17 @@ use super::types::{CssLength, LineHeight, WhiteSpace};
 /// registers a compact Chromium-derived UA sheet at `Origin::UserAgent`
 /// so elements receive browser-default styles automatically.
 pub(crate) fn collect_styled_tree(html: &str) -> Result<Option<StyledElement>, String> {
-    use csscascade::cascade::CascadeDriver;
-    use style::thread_state::{self, ThreadState};
-
-    thread_state::initialize(ThreadState::LAYOUT);
-
     // Enable CSS Grid support in Stylo's servo mode (one-time).
     // Without this, `display: grid` is not parsed (gated behind a pref).
+    // Renderer-side only — deliberately NOT part of the shared front-end,
+    // so the importer's Stylo behavior stays untouched.
     use std::sync::Once;
     static GRID_PREF: Once = Once::new();
     GRID_PREF.call_once(|| {
         stylo_static_prefs::set_pref!("layout.grid.enabled", true);
     });
 
-    let dom =
-        DemoDom::parse_from_bytes(html.as_bytes()).map_err(|e| format!("HTML parse error: {e}"))?;
-    let mut driver = CascadeDriver::new(&dom);
-    let document = adapter::bootstrap_dom(dom);
-    driver.flush(document);
-    let _styled_count = driver.style_document(document);
+    let document = super::frontend::parse_and_style(html)?;
 
     let root = document.root_element().map(collect_element);
     Ok(root)

--- a/crates/grida/src/htmlcss/collect.rs
+++ b/crates/grida/src/htmlcss/collect.rs
@@ -1175,6 +1175,9 @@ fn extract_style(tag: &str, style: &ComputedValues) -> StyledElement {
             _ => types::Display::Block,
         }
     };
+    // Outer display type — the (outside, inside) collapse above loses
+    // outer-inline for e.g. `inline flex`; carried for the importer.
+    el.inline_outside = display.outside() == style::values::specified::box_::DisplayOutside::Inline;
 
     // Visibility
     {
@@ -1289,6 +1292,7 @@ fn extract_style(tag: &str, style: &ComputedValues) -> StyledElement {
     // Box shadow
     el.box_shadow = extract_box_shadow(style, el.color);
     el.filter = extract_filter(style, el.color);
+    el.backdrop_filter = extract_backdrop_filter(style, el.color);
     el.clip_path = extract_clip_path(style);
 
     // Transform
@@ -1320,10 +1324,22 @@ fn extract_style(tag: &str, style: &ComputedValues) -> StyledElement {
         // so `safe`/`unsafe`/`legacy` modifier bits are masked out
         // (`AlignFlags` is a bitflags type; exact `==` on the whole
         // flag set would fail for e.g. `align-items: safe center`).
-        el.align_items = align_flags_to_items(style.clone_align_items().0.value());
-        el.justify_content =
-            align_flags_to_explicit_justify(style.clone_justify_content().primary().value())
-                .unwrap_or(types::JustifyContent::Start);
+        // Both stay `None` for `normal` (the CSS default) so consumers
+        // can tell authored-vs-default; htmlcss layout unwraps to
+        // today's effective defaults (`Stretch` / `Start`) at the point
+        // of use.
+        el.align_items = align_flags_to_explicit_items(style.clone_align_items().0.value());
+        let jc_flags = style.clone_justify_content().primary().value();
+        el.justify_content = {
+            use style::values::specified::align::AlignFlags;
+            if jc_flags == AlignFlags::STRETCH {
+                // Recognized here only — align-content keeps deferring
+                // `stretch` to Taffy via `None`.
+                Some(types::JustifyContent::Stretch)
+            } else {
+                align_flags_to_explicit_justify(jc_flags)
+            }
+        };
         // gap
         use style::values::generics::length::LengthPercentageOrNormal;
         let gap_to_px =
@@ -1681,6 +1697,7 @@ fn convert_image(
                 let angle_deg = extract_gradient_angle(direction);
                 Some(StyleImage::LinearGradient(LinearGradient {
                     angle_deg,
+                    keyword: extract_gradient_keyword(direction),
                     stops,
                     repeating: is_repeating(flags),
                     interpolation: extract_gradient_interpolation(color_interpolation_method),
@@ -2123,6 +2140,32 @@ fn extract_gradient_angle(direction: &style::values::computed::image::LineDirect
     }
 }
 
+/// Keyword identity of a linear-gradient direction — `Some` when the
+/// authored value was `to <side-or-corner>`, `None` for angles.
+/// `extract_gradient_angle` collapses keywords to an angle for paint;
+/// this preserves the exact endpoint identity (corner directions have
+/// no exact angle) for consumers that map endpoints directly.
+fn extract_gradient_keyword(
+    direction: &style::values::computed::image::LineDirection,
+) -> Option<GradientKeyword> {
+    use style::values::computed::image::LineDirection;
+    use style::values::specified::position::{HorizontalPositionKeyword, VerticalPositionKeyword};
+
+    match direction {
+        LineDirection::Angle(_) => None,
+        LineDirection::Vertical(VerticalPositionKeyword::Top) => Some(GradientKeyword::ToTop),
+        LineDirection::Vertical(VerticalPositionKeyword::Bottom) => Some(GradientKeyword::ToBottom),
+        LineDirection::Horizontal(HorizontalPositionKeyword::Left) => Some(GradientKeyword::ToLeft),
+        LineDirection::Horizontal(HorizontalPositionKeyword::Right) => {
+            Some(GradientKeyword::ToRight)
+        }
+        LineDirection::Corner(h, v) => Some(GradientKeyword::Corner {
+            right: matches!(h, HorizontalPositionKeyword::Right),
+            bottom: matches!(v, VerticalPositionKeyword::Bottom),
+        }),
+    }
+}
+
 /// Convert Stylo gradient items to GradientStops.
 ///
 /// `currentcolor` stops (unresolvable to absolute) resolve to `current_color`
@@ -2459,10 +2502,22 @@ fn extract_inset_corner_radii(
 }
 
 fn extract_filter(style: &ComputedValues, current_color: CGColor) -> Vec<FilterFunction> {
+    filter_list_to_functions(&style.clone_filter().0, current_color)
+}
+
+/// `backdrop-filter` — same value grammar as `filter`. htmlcss paint
+/// does not consume it; carried on the style record for the HTML
+/// importer.
+fn extract_backdrop_filter(style: &ComputedValues, current_color: CGColor) -> Vec<FilterFunction> {
+    filter_list_to_functions(&style.clone_backdrop_filter().0, current_color)
+}
+
+fn filter_list_to_functions(
+    filters: &[style::values::computed::Filter],
+    current_color: CGColor,
+) -> Vec<FilterFunction> {
     use style::values::generics::effects::GenericFilter;
-    style
-        .clone_filter()
-        .0
+    filters
         .iter()
         .filter_map(|f| match f {
             GenericFilter::Blur(len) => Some(FilterFunction::Blur(len.0.px())),
@@ -2635,6 +2690,27 @@ fn extract_font(style: &ComputedValues, current_color: CGColor) -> FontProps {
         })
         .collect();
 
+    // Identity of the leading generic family — the mapping above
+    // collapses every generic to "system-ui" for htmlcss font
+    // resolution; the HTML importer needs the generic itself.
+    let first_generic = font.font_family.families.iter().next().and_then(|f| {
+        use style::values::computed::font::{GenericFontFamily, SingleFontFamily};
+        match f {
+            SingleFontFamily::Generic(g) => match g {
+                GenericFontFamily::Serif => Some(types::GenericFamily::Serif),
+                GenericFontFamily::SansSerif => Some(types::GenericFamily::SansSerif),
+                GenericFontFamily::Monospace => Some(types::GenericFamily::Monospace),
+                GenericFontFamily::Cursive => Some(types::GenericFamily::Cursive),
+                GenericFontFamily::Fantasy => Some(types::GenericFamily::Fantasy),
+                GenericFontFamily::SystemUi => Some(types::GenericFamily::SystemUi),
+                // Stylo's internal `None` ("no generic") and any
+                // build-gated variants carry no identity.
+                _ => None,
+            },
+            SingleFontFamily::FamilyName(_) => None,
+        }
+    });
+
     let line_height = match &font.line_height {
         StyloLineHeight::Normal => LineHeight::Normal,
         StyloLineHeight::Number(n) => LineHeight::Number(n.0),
@@ -2658,6 +2734,7 @@ fn extract_font(style: &ComputedValues, current_color: CGColor) -> FontProps {
         weight: FontWeight(font.font_weight.value() as u32),
         italic: font.font_style == style::values::computed::FontStyle::ITALIC,
         families,
+        first_generic,
         line_height,
         letter_spacing,
         word_spacing,
@@ -2948,6 +3025,29 @@ fn align_flags_to_items(flags: style::values::specified::align::AlignFlags) -> t
         f if f == AlignFlags::FLEX_END || f == AlignFlags::END => types::AlignItems::End,
         f if f == AlignFlags::BASELINE => types::AlignItems::Baseline,
         _ => types::AlignItems::Stretch,
+    }
+}
+
+/// Map align/justify flags to an optional `AlignItems`. Returns `None`
+/// for `normal` (the CSS default) and unrecognized values so consumers
+/// can tell authored-vs-default; htmlcss layout unwraps to `Stretch`
+/// (today's effective default) at the point of use.
+fn align_flags_to_explicit_items(
+    flags: style::values::specified::align::AlignFlags,
+) -> Option<types::AlignItems> {
+    // See `align_flags_to_items` — caller passes keyword-only flags
+    // (post `.value()`); use `==` rather than `contains()` because the
+    // low-5-bit keyword values overlap bitwise.
+    use style::values::specified::align::AlignFlags;
+    match flags {
+        f if f == AlignFlags::CENTER => Some(types::AlignItems::Center),
+        f if f == AlignFlags::FLEX_START || f == AlignFlags::START => {
+            Some(types::AlignItems::Start)
+        }
+        f if f == AlignFlags::FLEX_END || f == AlignFlags::END => Some(types::AlignItems::End),
+        f if f == AlignFlags::BASELINE => Some(types::AlignItems::Baseline),
+        f if f == AlignFlags::STRETCH => Some(types::AlignItems::Stretch),
+        _ => None,
     }
 }
 

--- a/crates/grida/src/htmlcss/frontend.rs
+++ b/crates/grida/src/htmlcss/frontend.rs
@@ -1,0 +1,44 @@
+//! Shared HTML → styled-DOM front-end.
+//!
+//! One home for the parse-and-cascade sequence that was previously
+//! duplicated verbatim between the htmlcss renderer
+//! (`collect_styled_tree`) and the HTML importer
+//! (`import::html::from_html_str`) — see the seam program,
+//! gridaco/nothing#30.
+//!
+//! Deliberately excluded: pref toggles (e.g. `layout.grid.enabled`,
+//! which stays renderer-side in `collect_styled_tree`) so each caller's
+//! Stylo behavior is exactly what it was before the share.
+//!
+//! # Thread safety
+//!
+//! Uses the process-global DOM slot ([`csscascade::adapter::DEMO_DOM`]);
+//! callers serialize externally, exactly as before.
+
+use csscascade::adapter::{self, HtmlDocument};
+use csscascade::cascade::CascadeDriver;
+use csscascade::dom::DemoDom;
+use style::thread_state::{self, ThreadState};
+
+/// Parse HTML and resolve styles via Stylo, returning the styled
+/// document handle installed in the global DOM slot.
+pub(crate) fn parse_and_style(html: &str) -> Result<HtmlDocument, String> {
+    // Ensure Stylo thread state is initialized (idempotent after first call).
+    thread_state::initialize(ThreadState::LAYOUT);
+
+    // 1. Parse HTML into arena DOM
+    let dom =
+        DemoDom::parse_from_bytes(html.as_bytes()).map_err(|e| format!("HTML parse error: {e}"))?;
+
+    // 2. Build cascade driver (collects <style> blocks, builds UA + author sheets)
+    let mut driver = CascadeDriver::new(&dom);
+
+    // 3. Install DOM into global slot
+    let document = adapter::bootstrap_dom(dom);
+
+    // 4. Flush stylist + resolve all styles
+    driver.flush(document);
+    let _styled_count = driver.style_document(document);
+
+    Ok(document)
+}

--- a/crates/grida/src/htmlcss/layout.rs
+++ b/crates/grida/src/htmlcss/layout.rs
@@ -459,9 +459,15 @@ fn element_to_taffy_style(el: &StyledElement) -> taffy::Style {
             types::FlexWrap::Wrap => taffy::FlexWrap::Wrap,
             types::FlexWrap::WrapReverse => taffy::FlexWrap::WrapReverse,
         },
-        align_items: Some(map_align_items(el.align_items)),
+        // `None` = authored `normal` (the CSS default) — unwrap to
+        // today's effective defaults so layout behavior is unchanged.
+        align_items: Some(map_align_items(
+            el.align_items.unwrap_or(types::AlignItems::Stretch),
+        )),
         justify_items: Some(map_align_items(el.justify_items)),
-        justify_content: Some(map_justify_content(el.justify_content)),
+        justify_content: Some(map_justify_content(
+            el.justify_content.unwrap_or(types::JustifyContent::Start),
+        )),
         align_content: el.align_content.map(map_justify_content),
         gap: taffy::Size {
             width: LengthPercentage::length(el.column_gap),
@@ -641,6 +647,9 @@ fn map_justify_content(j: types::JustifyContent) -> taffy::JustifyContent {
         types::JustifyContent::SpaceBetween => taffy::JustifyContent::SpaceBetween,
         types::JustifyContent::SpaceAround => taffy::JustifyContent::SpaceAround,
         types::JustifyContent::SpaceEvenly => taffy::JustifyContent::SpaceEvenly,
+        // Taffy has no justify-content:stretch mapping yet — fall back
+        // to Start, today's effective value for unrecognized keywords.
+        types::JustifyContent::Stretch => taffy::JustifyContent::FlexStart,
     }
 }
 

--- a/crates/grida/src/htmlcss/mod.rs
+++ b/crates/grida/src/htmlcss/mod.rs
@@ -11,6 +11,7 @@
 
 mod collect;
 mod faux_table;
+pub(crate) mod frontend;
 mod github_markdown;
 mod layout;
 mod paint;

--- a/crates/grida/src/htmlcss/mod.rs
+++ b/crates/grida/src/htmlcss/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! Uses Stylo's process-global DOM slot. Calls must be serialized externally.
 
-mod collect;
+pub(crate) mod collect;
 mod faux_table;
 pub(crate) mod frontend;
 mod github_markdown;

--- a/crates/grida/src/htmlcss/style.rs
+++ b/crates/grida/src/htmlcss/style.rs
@@ -337,6 +337,13 @@ pub struct CssEdgeInsets {
 pub struct BorderSide {
     pub width: f32,
     pub color: CGColor,
+    /// `true` when the authored side color was `currentcolor` (the CSS
+    /// initial value — every side whose color is never authored carries
+    /// it). `color` holds the resolved value (the element's computed
+    /// `color`), which is what htmlcss paint consumes. Preserved for
+    /// the HTML importer, whose stroke-color fallback skips
+    /// `currentcolor` sides — pinned by its golden corpus.
+    pub color_is_currentcolor: bool,
     pub style: BorderStyle,
 }
 
@@ -345,6 +352,7 @@ impl Default for BorderSide {
         Self {
             width: 0.0,
             color: CGColor::BLACK,
+            color_is_currentcolor: false,
             style: BorderStyle::None,
         }
     }

--- a/crates/grida/src/htmlcss/style.rs
+++ b/crates/grida/src/htmlcss/style.rs
@@ -969,6 +969,13 @@ pub struct GradientStop {
     pub offset: f32,
     pub offset_is_px: bool,
     pub color: CGColor,
+    /// `true` when the authored stop color was `currentcolor` — `color`
+    /// carries the value it resolved to (the element's computed `color`)
+    /// per CSS Color 3 §4.4, which is what htmlcss paint consumes.
+    /// Preserved for consumers that need the unresolved identity: the
+    /// HTML importer folds `currentcolor` stops to transparent black
+    /// today, and its output is pinned by the import snapshot corpus.
+    pub color_is_currentcolor: bool,
 }
 
 // ─── Text / Font Sub-types (StyleInheritedData) ──────────────────────
@@ -991,6 +998,11 @@ pub struct FontProps {
     pub letter_spacing: f32,
     pub word_spacing: f32,
     pub text_align: TextAlign,
+    /// The authored `text-align` keyword before `start`/`end` are
+    /// resolved against `direction` — see [`super::types::TextAlignKeyword`].
+    /// `text_align` above is the resolved value htmlcss consumes; the
+    /// HTML importer maps the keyword to a physical alignment itself.
+    pub text_align_keyword: super::types::TextAlignKeyword,
     pub text_transform: TextTransform,
     pub direction: super::types::Direction,
     /// Bitfield: multiple decorations can be active simultaneously.
@@ -1024,6 +1036,7 @@ impl Default for FontProps {
             letter_spacing: 0.0,
             word_spacing: 0.0,
             text_align: TextAlign::Left,
+            text_align_keyword: super::types::TextAlignKeyword::Start,
             text_transform: TextTransform::None,
             direction: super::types::Direction::Ltr,
             decoration_underline: false,

--- a/crates/grida/src/htmlcss/style.rs
+++ b/crates/grida/src/htmlcss/style.rs
@@ -34,6 +34,11 @@ pub struct StyledElement {
 
     // ── Display (StyleBoxData) ──
     pub display: Display,
+    /// Whether the outer display type is `inline`. The `(outside, inside)`
+    /// → [`Display`] collapse loses outer-inline for e.g. `inline flex`
+    /// (mapped to `Flex`); this preserves it for consumers that need the
+    /// outer type (the HTML importer). htmlcss layout does not read it.
+    pub inline_outside: bool,
     pub visibility: Visibility,
     pub box_sizing: BoxSizing,
 
@@ -86,6 +91,9 @@ pub struct StyledElement {
     /// CSS `filter` chain, applied in order to the element and its
     /// descendants via a paint layer wrapped in a Skia `ImageFilter`.
     pub filter: Vec<FilterFunction>,
+    /// CSS `backdrop-filter` chain — same value grammar as `filter`.
+    /// htmlcss paint does not consume it; carried for the HTML importer.
+    pub backdrop_filter: Vec<FilterFunction>,
     /// CSS `clip-path` — clips the element and its descendants to a
     /// basic shape. Evaluated at paint time against the element's
     /// border box.
@@ -108,8 +116,14 @@ pub struct StyledElement {
     // ── Flex container (rare non-inherited) ──
     pub flex_direction: FlexDirection,
     pub flex_wrap: FlexWrap,
-    pub align_items: AlignItems,
-    pub justify_content: JustifyContent,
+    /// `None` means the CSS default (`normal`, which behaves like
+    /// `stretch`) — preserved so consumers can tell authored-vs-default.
+    /// htmlcss layout unwraps to `Stretch` at the point of use.
+    pub align_items: Option<AlignItems>,
+    /// `None` means the CSS default (`normal`) — preserved so consumers
+    /// can tell authored-vs-default. htmlcss layout unwraps to `Start`
+    /// at the point of use.
+    pub justify_content: Option<JustifyContent>,
     /// Per-cell alignment of grid items along the inline axis.
     /// Ignored by flex containers.
     pub justify_items: AlignItems,
@@ -848,9 +862,33 @@ pub struct GradientInterpolation {
 pub struct LinearGradient {
     /// Angle in CSS degrees (0 = to top, 90 = to right, 180 = to bottom).
     pub angle_deg: f32,
+    /// Set when the authored direction was a `to <side-or-corner>`
+    /// keyword rather than an angle. `angle_deg` always carries the
+    /// equivalent angle for paint; the keyword preserves the exact
+    /// endpoint identity (corner directions have no exact angle, and
+    /// float trig loses axis exactness) for consumers that map
+    /// endpoints directly — the HTML importer. htmlcss paint consumes
+    /// `angle_deg` only.
+    pub keyword: Option<GradientKeyword>,
     pub stops: Vec<GradientStop>,
     pub repeating: bool,
     pub interpolation: GradientInterpolation,
+}
+
+/// The `to <side-or-corner>` direction of a linear gradient — mirror of
+/// Stylo's `LineDirection` keyword cases (`Vertical`, `Horizontal`,
+/// `Corner`); angle directions have no keyword.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GradientKeyword {
+    ToTop,
+    ToBottom,
+    ToLeft,
+    ToRight,
+    /// `to <left|right> <top|bottom>` — the target corner.
+    Corner {
+        right: bool,
+        bottom: bool,
+    },
 }
 
 /// CSS `radial-gradient()` / `repeating-radial-gradient()`.
@@ -944,6 +982,11 @@ pub struct FontProps {
     pub weight: FontWeight,
     pub italic: bool,
     pub families: Vec<String>,
+    /// Identity of the first family when it is a generic (`sans-serif`,
+    /// `monospace`, …). `families` collapses every generic to
+    /// `"system-ui"` for htmlcss font resolution; the HTML importer
+    /// needs the generic itself.
+    pub first_generic: Option<GenericFamily>,
     pub line_height: LineHeight,
     pub letter_spacing: f32,
     pub word_spacing: f32,
@@ -976,6 +1019,7 @@ impl Default for FontProps {
             weight: FontWeight::REGULAR400,
             italic: false,
             families: vec!["system-ui".into(), "sans-serif".into()],
+            first_generic: None,
             line_height: LineHeight::Normal,
             letter_spacing: 0.0,
             word_spacing: 0.0,
@@ -1137,6 +1181,7 @@ impl Default for StyledElement {
         Self {
             tag: String::new(),
             display: Display::Block,
+            inline_outside: false,
             visibility: Visibility::Visible,
             box_sizing: BoxSizing::default(),
             width: CssLength::Auto,
@@ -1162,6 +1207,7 @@ impl Default for StyledElement {
             overflow_clip_margin: 0.0,
             box_shadow: Vec::new(),
             filter: Vec::new(),
+            backdrop_filter: Vec::new(),
             clip_path: ClipPath::None,
             transform: Vec::new(),
             transform_origin: TransformOrigin::default(),
@@ -1172,8 +1218,8 @@ impl Default for StyledElement {
             clear: Clear::None,
             flex_direction: FlexDirection::default(),
             flex_wrap: FlexWrap::default(),
-            align_items: AlignItems::default(),
-            justify_content: JustifyContent::default(),
+            align_items: None,
+            justify_content: None,
             justify_items: AlignItems::default(),
             align_content: None,
             row_gap: 0.0,

--- a/crates/grida/src/htmlcss/types.rs
+++ b/crates/grida/src/htmlcss/types.rs
@@ -240,6 +240,26 @@ pub enum Direction {
     Rtl,
 }
 
+/// The authored CSS `text-align` keyword, before the logical
+/// `start`/`end` keywords are resolved against `direction`.
+///
+/// `FontProps::text_align` carries the direction-resolved physical value
+/// that htmlcss layout/paint consume; this preserves the keyword's
+/// identity for consumers that resolve logical keywords themselves (the
+/// HTML importer maps `start` → left and `end` → right regardless of
+/// direction). Legacy `-moz-*` aliases collapse to their physical
+/// equivalents at extraction, matching both consumers' handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TextAlignKeyword {
+    #[default]
+    Start,
+    End,
+    Left,
+    Right,
+    Center,
+    Justify,
+}
+
 /// CSS `vertical-align` property (inline-level).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VerticalAlign {

--- a/crates/grida/src/htmlcss/types.rs
+++ b/crates/grida/src/htmlcss/types.rs
@@ -123,6 +123,11 @@ pub enum JustifyContent {
     SpaceBetween,
     SpaceAround,
     SpaceEvenly,
+    /// `justify-content: stretch`. Only produced by the justify-content
+    /// extraction (align-content keeps deferring `stretch` to Taffy via
+    /// `None`). Taffy has no justify-content:stretch mapping yet, so
+    /// htmlcss layout falls back to `Start` at the point of use.
+    Stretch,
 }
 
 /// A CSS length value. Percentages are kept as-is for Taffy to resolve.
@@ -164,6 +169,23 @@ pub enum LineHeight {
     Normal,
     Number(f32),
     Px(f32),
+}
+
+/// CSS generic font family keyword — mirror of Stylo's
+/// `GenericFontFamily` (the variants reachable in this build; Stylo's
+/// internal `None` maps to the absence of a generic).
+///
+/// htmlcss font resolution collapses every generic to `"system-ui"` in
+/// `FontProps::families`; this preserves the generic's identity for
+/// consumers that need it (the HTML importer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenericFamily {
+    Serif,
+    SansSerif,
+    Monospace,
+    Cursive,
+    Fantasy,
+    SystemUi,
 }
 
 /// CSS `float` property.

--- a/crates/grida/src/import/html/from_styled.rs
+++ b/crates/grida/src/import/html/from_styled.rs
@@ -1,0 +1,194 @@
+//! Pure mappings from the shared per-element style record
+//! ([`StyledElement`]) to the types the HTML importer's emitters consume.
+//!
+//! This is the importer's half of the htmlcss seam (gridaco/nothing#30):
+//! `crate::htmlcss::collect::styled_of` extracts one element's resolved
+//! style into a [`StyledElement`]; the functions here map that record
+//! onto v1 node-record fields. Every function is pure and total — no
+//! Stylo types, no DOM access.
+//!
+//! The mappings reproduce the importer's pinned behavior (the
+//! `html_import_snapshot` golden corpus) exactly; where the record is
+//! richer than what the importer historically consumed (percent radii,
+//! `repeating` gradient flags, flex-basis, …), the extra information is
+//! deliberately dropped, matching the old `ComputedValues` walk.
+
+use crate::cg::prelude::*;
+use crate::node::schema::*;
+
+use crate::htmlcss::style::StyledElement;
+use crate::htmlcss::types::AlignItems as CssAlignItems;
+use crate::htmlcss::types::{
+    CssLength, Display, FlexDirection, FlexWrap, JustifyContent, Position,
+};
+
+use super::CSSMargin;
+
+/// CSS `width`/`height`/`min-*`/`max-*` → [`LayoutDimensionStyle`].
+///
+/// Only definite px lengths are honored; `auto` clears the target
+/// dimension (containers default to the factory's 100×100 otherwise)
+/// and percentages/calc leave the field untouched — the importer has
+/// never resolved them (no containing-block size at import time).
+pub(super) fn dimensions_from(el: &StyledElement, dims: &mut LayoutDimensionStyle) {
+    match el.width {
+        CssLength::Px(v) => dims.layout_target_width = Some(v),
+        CssLength::Auto => dims.layout_target_width = None,
+        _ => {}
+    }
+    match el.height {
+        CssLength::Px(v) => dims.layout_target_height = Some(v),
+        CssLength::Auto => dims.layout_target_height = None,
+        _ => {}
+    }
+    if let CssLength::Px(v) = el.min_width {
+        if v > 0.0 {
+            dims.layout_min_width = Some(v);
+        }
+    }
+    if let CssLength::Px(v) = el.min_height {
+        if v > 0.0 {
+            dims.layout_min_height = Some(v);
+        }
+    }
+    if let CssLength::Px(v) = el.max_width {
+        dims.layout_max_width = Some(v);
+    }
+    if let CssLength::Px(v) = el.max_height {
+        dims.layout_max_height = Some(v);
+    }
+}
+
+/// CSS `width`/`height` → a leaf [`Size`] (Rectangle nodes).
+///
+/// `auto`, percentages, and calc all resolve to `0×0` — unlike the
+/// design-tool convention (100×100 default), HTML leaf elements have no
+/// intrinsic size.
+pub(super) fn size_from(el: &StyledElement) -> Size {
+    let px = |v: CssLength| -> f32 {
+        match v {
+            CssLength::Px(p) => p,
+            _ => 0.0,
+        }
+    };
+    Size {
+        width: px(el.width),
+        height: px(el.height),
+    }
+}
+
+/// Flex-child properties (`flex-grow`, absolute positioning) →
+/// [`LayoutChildStyle`]. `None` when all values are at their defaults
+/// (grow = 0, position static/relative).
+pub(super) fn layout_child_from(el: &StyledElement) -> Option<LayoutChildStyle> {
+    let grow = el.flex_grow;
+    // The record maps `position: fixed` to `Position::Absolute` at
+    // extraction (Stylo's `is_absolutely_positioned` covers both), so
+    // one variant check matches the old ComputedValues read.
+    let is_absolute = el.position == Position::Absolute;
+    if grow > 0.0 || is_absolute {
+        Some(LayoutChildStyle {
+            layout_grow: grow,
+            layout_positioning: if is_absolute {
+                LayoutPositioning::Absolute
+            } else {
+                LayoutPositioning::Auto
+            },
+        })
+    } else {
+        None
+    }
+}
+
+/// Flex-container properties (`display`, direction, wrap, alignment,
+/// gap) → [`LayoutContainerStyle`].
+///
+/// Non-flex displays (block, grid, table, …) map to a Flex column: the
+/// IR's `LayoutMode::Normal` maps to taffy `Display::Block`, which
+/// causes children of a flex parent to stretch to 100% width (block
+/// intrinsic sizing). Using Flex column instead gives correct sizing
+/// when these containers are nested inside flex parents.
+pub(super) fn flex_container_from(el: &StyledElement, out: &mut LayoutContainerStyle) {
+    out.layout_mode = LayoutMode::Flex;
+    if el.display != Display::Flex {
+        out.layout_direction = Axis::Vertical;
+        return;
+    }
+
+    out.layout_direction = match el.flex_direction {
+        FlexDirection::Row | FlexDirection::RowReverse => Axis::Horizontal,
+        FlexDirection::Column | FlexDirection::ColumnReverse => Axis::Vertical,
+    };
+
+    out.layout_wrap = Some(match el.flex_wrap {
+        FlexWrap::Nowrap => LayoutWrap::NoWrap,
+        FlexWrap::Wrap | FlexWrap::WrapReverse => LayoutWrap::Wrap,
+    });
+
+    // align-items → cross axis alignment. `None` is the record's
+    // authored-`normal` (and unrecognized-keyword) case — the importer
+    // leaves the field unset; `baseline` has no IR equivalent and joins
+    // it, exactly like the old AlignFlags fall-through arm.
+    out.layout_cross_axis_alignment = match el.align_items {
+        Some(CssAlignItems::Center) => Some(CrossAxisAlignment::Center),
+        Some(CssAlignItems::Start) => Some(CrossAxisAlignment::Start),
+        Some(CssAlignItems::End) => Some(CrossAxisAlignment::End),
+        Some(CssAlignItems::Stretch) => Some(CrossAxisAlignment::Stretch),
+        Some(CssAlignItems::Baseline) | None => None,
+    };
+
+    // justify-content → main axis alignment. `None` (authored `normal`
+    // or unrecognized) leaves the field unset, as before.
+    out.layout_main_axis_alignment = match el.justify_content {
+        Some(JustifyContent::Center) => Some(MainAxisAlignment::Center),
+        Some(JustifyContent::Start) => Some(MainAxisAlignment::Start),
+        Some(JustifyContent::End) => Some(MainAxisAlignment::End),
+        Some(JustifyContent::SpaceBetween) => Some(MainAxisAlignment::SpaceBetween),
+        Some(JustifyContent::SpaceAround) => Some(MainAxisAlignment::SpaceAround),
+        Some(JustifyContent::SpaceEvenly) => Some(MainAxisAlignment::SpaceEvenly),
+        Some(JustifyContent::Stretch) => Some(MainAxisAlignment::Stretch),
+        None => None,
+    };
+
+    // Gap (flex containers only).
+    // CSS column-gap = inline-axis gap, row-gap = block-axis gap.
+    // For flex-direction: row, column-gap is the main-axis gap.
+    // For flex-direction: column, row-gap is the main-axis gap.
+    if el.row_gap != 0.0 || el.column_gap != 0.0 {
+        let (main_gap, cross_gap) = match el.flex_direction {
+            FlexDirection::Row | FlexDirection::RowReverse => (el.column_gap, el.row_gap),
+            FlexDirection::Column | FlexDirection::ColumnReverse => (el.row_gap, el.column_gap),
+        };
+        out.layout_gap = Some(LayoutGap {
+            main_axis_gap: main_gap,
+            cross_axis_gap: cross_gap,
+        });
+    }
+}
+
+/// CSS margin → the importer's margin-surgery input. The record stores
+/// each side as `Auto` or a resolved px length (percent margins resolve
+/// to 0 at extraction, as the old walk did).
+pub(super) fn margin_from(el: &StyledElement) -> CSSMargin {
+    let side = |v: CssLength| -> (f32, bool) {
+        match v {
+            CssLength::Auto => (0.0, true),
+            CssLength::Px(p) => (p, false),
+            _ => (0.0, false),
+        }
+    };
+    let (top, top_auto) = side(el.margin.top);
+    let (right, right_auto) = side(el.margin.right);
+    let (bottom, bottom_auto) = side(el.margin.bottom);
+    let (left, left_auto) = side(el.margin.left);
+    CSSMargin {
+        top,
+        right,
+        bottom,
+        left,
+        top_auto,
+        right_auto,
+        bottom_auto,
+        left_auto,
+    }
+}

--- a/crates/grida/src/import/html/from_styled.rs
+++ b/crates/grida/src/import/html/from_styled.rs
@@ -16,13 +16,27 @@
 use crate::cg::prelude::*;
 use crate::node::schema::*;
 
-use crate::htmlcss::style::StyledElement;
+use crate::htmlcss::style::{
+    BackgroundImage, BackgroundLayer, FilterFunction, GradientKeyword,
+    GradientStop as CssGradientStop, LinearGradient as CssLinearGradient, StyleImage,
+    StyledElement,
+};
 use crate::htmlcss::types::AlignItems as CssAlignItems;
 use crate::htmlcss::types::{
-    CssLength, Display, FlexDirection, FlexWrap, JustifyContent, Position,
+    BorderStyle as CssBorderStyle, CssLength, Display, FlexDirection, FlexWrap, JustifyContent,
+    Position,
 };
 
 use super::CSSMargin;
+
+/// The importer's solid paint shape — default blend, active.
+fn solid(color: CGColor) -> Paint {
+    Paint::Solid(SolidPaint {
+        color,
+        blend_mode: BlendMode::default(),
+        active: true,
+    })
+}
 
 /// CSS `width`/`height`/`min-*`/`max-*` → [`LayoutDimensionStyle`].
 ///
@@ -163,6 +177,285 @@ pub(super) fn flex_container_from(el: &StyledElement, out: &mut LayoutContainerS
             main_axis_gap: main_gap,
             cross_axis_gap: cross_gap,
         });
+    }
+}
+
+/// Record gradient stops → CG gradient stops.
+///
+/// - `currentcolor` stops and fully-transparent stops fold to
+///   transparent black — the goldens pin that fold (the old
+///   `css_color_to_cg(..).unwrap_or(clear)` behavior).
+/// - px-positioned offsets fold to `0.0`: the importer has never
+///   resolved absolute lengths along the gradient line (no geometry at
+///   import time).
+fn stops_from(stops: &[CssGradientStop]) -> Vec<GradientStop> {
+    stops
+        .iter()
+        .map(|s| GradientStop {
+            offset: if s.offset_is_px { 0.0 } else { s.offset },
+            color: if s.color_is_currentcolor || s.color.a == 0 {
+                CGColor::from_rgba(0, 0, 0, 0)
+            } else {
+                s.color
+            },
+        })
+        .collect()
+}
+
+/// CSS linear-gradient direction → IR Alignment endpoints.
+///
+/// CSS gradient angles: 0deg = to top, 90deg = to right, 180deg = to bottom.
+/// IR Alignment: (-1,-1) = top-left, (0,0) = center, (1,1) = bottom-right.
+///
+/// `to <side-or-corner>` keywords map to exact axis/corner constants;
+/// angle directions go through trig.
+fn linear_endpoints(g: &CssLinearGradient) -> (Alignment, Alignment) {
+    match g.keyword {
+        Some(GradientKeyword::ToTop) => (Alignment::BOTTOM_CENTER, Alignment::TOP_CENTER),
+        Some(GradientKeyword::ToBottom) => (Alignment::TOP_CENTER, Alignment::BOTTOM_CENTER),
+        Some(GradientKeyword::ToLeft) => (Alignment::CENTER_RIGHT, Alignment::CENTER_LEFT),
+        Some(GradientKeyword::ToRight) => (Alignment::CENTER_LEFT, Alignment::CENTER_RIGHT),
+        Some(GradientKeyword::Corner { right, bottom }) => {
+            let x1 = if right { -1.0 } else { 1.0 };
+            let y1 = if bottom { -1.0 } else { 1.0 };
+            (Alignment(x1, y1), Alignment(-x1, -y1))
+        }
+        None => {
+            // Replicate Stylo's computed `Angle::radians()` bit-for-bit:
+            // the record's `angle_deg` is the stored f32 degrees; the
+            // deg→rad conversion runs in f64 and narrows, exactly like
+            // the old direct `radians()` read.
+            let rad = ((g.angle_deg as f64) * (std::f64::consts::PI / 180.0))
+                .min(f32::MAX as f64)
+                .max(f32::MIN as f64) as f32;
+            let sin = rad.sin();
+            let cos = rad.cos();
+            // CSS gradient line: from (-sin, cos) to (sin, -cos) in NDC
+            (Alignment(-sin, cos), Alignment(sin, -cos))
+        }
+    }
+}
+
+/// CSS background (color + gradient image layers) → fill paints.
+///
+/// The record stores image layers bottom-to-top (reverse source order)
+/// for the renderer's paint loop; the importer emits the solid color
+/// first, then gradients in source order — so image layers are
+/// re-reversed here. Raster (`url()`) backgrounds are not imported.
+pub(super) fn fills_from_background(el: &StyledElement) -> Paints {
+    let mut paints: Vec<Paint> = Vec::new();
+    let mut images: Vec<&BackgroundImage> = Vec::new();
+
+    // 1. Background color (bottom layer). The record already omits it
+    //    when fully transparent (the old a == 0 fold).
+    for layer in &el.background {
+        match layer {
+            BackgroundLayer::Solid { color, .. } => paints.push(solid(*color)),
+            BackgroundLayer::Image(img) => images.push(img),
+        }
+    }
+
+    // 2. Gradient layers on top, in source order.
+    for img in images.iter().rev() {
+        match &img.source {
+            StyleImage::LinearGradient(g) => {
+                let (xy1, xy2) = linear_endpoints(g);
+                paints.push(Paint::LinearGradient(LinearGradientPaint {
+                    active: true,
+                    xy1,
+                    xy2,
+                    stops: stops_from(&g.stops),
+                    ..Default::default()
+                }));
+            }
+            StyleImage::RadialGradient(g) => {
+                paints.push(Paint::RadialGradient(RadialGradientPaint::from_stops(
+                    stops_from(&g.stops),
+                )));
+            }
+            StyleImage::ConicGradient(g) => {
+                paints.push(Paint::SweepGradient(SweepGradientPaint {
+                    active: true,
+                    stops: stops_from(&g.stops),
+                    ..Default::default()
+                }));
+            }
+            StyleImage::Url(_) => {}
+        }
+    }
+
+    if paints.is_empty() {
+        Paints::default()
+    } else {
+        Paints::new(paints)
+    }
+}
+
+/// Border radius → per-corner px radii. Percent components drop to
+/// `0.0` — the importer has never resolved them (no box size at import
+/// time); a calc radius carrying any percent term drops entirely,
+/// matching the old `to_length()`-or-zero read.
+pub(super) fn corner_radius_from(el: &StyledElement) -> RectangularCornerRadius {
+    let r = &el.border_radius;
+    let px = |v: f32, pct: f32| -> f32 {
+        if pct != 0.0 {
+            0.0
+        } else {
+            v
+        }
+    };
+    RectangularCornerRadius {
+        tl: Radius {
+            rx: px(r.tl_x, r.tl_x_pct),
+            ry: px(r.tl_y, r.tl_y_pct),
+        },
+        tr: Radius {
+            rx: px(r.tr_x, r.tr_x_pct),
+            ry: px(r.tr_y, r.tr_y_pct),
+        },
+        br: Radius {
+            rx: px(r.br_x, r.br_x_pct),
+            ry: px(r.br_y, r.br_y_pct),
+        },
+        bl: Radius {
+            rx: px(r.bl_x, r.bl_x_pct),
+            ry: px(r.bl_y, r.bl_y_pct),
+        },
+    }
+}
+
+/// CSS borders → strokes, stroke width, and stroke style.
+///
+/// The importer's border model: one stroke paint (the first
+/// non-transparent side color in top→right→bottom→left order), uniform
+/// or per-side widths, and a dash pattern from the top side's line
+/// style. Side widths are already zeroed for `none`/`hidden` styles at
+/// extraction.
+pub(super) fn strokes_from_border(el: &StyledElement) -> (Paints, StrokeWidth, StrokeStyle) {
+    let b = &el.border;
+    let (top_w, right_w, bottom_w, left_w) =
+        (b.top.width, b.right.width, b.bottom.width, b.left.width);
+
+    let has_border = top_w > 0.0 || right_w > 0.0 || bottom_w > 0.0 || left_w > 0.0;
+    if !has_border {
+        return (Paints::default(), StrokeWidth::None, StrokeStyle::default());
+    }
+
+    // Use the top border color as the primary stroke color (most common
+    // single-color case); for per-side colors, the first visible border
+    // side. `currentcolor` sides (the initial value — carried by every
+    // side whose color was never authored) and fully-transparent sides
+    // are skipped, reproducing the old `css_color_to_cg` fold.
+    let border_color = [&b.top, &b.right, &b.bottom, &b.left]
+        .into_iter()
+        .find(|s| !s.color_is_currentcolor && s.color.a != 0)
+        .map(|s| s.color);
+
+    let strokes = match border_color {
+        Some(color) => Paints::new([solid(color)]),
+        None => return (Paints::default(), StrokeWidth::None, StrokeStyle::default()),
+    };
+
+    // Stroke width: use rectangular if sides differ, uniform otherwise
+    let stroke_width = if top_w == right_w && right_w == bottom_w && bottom_w == left_w {
+        StrokeWidth::Uniform(top_w)
+    } else {
+        StrokeWidth::Rectangular(RectangularStrokeWidth {
+            stroke_top_width: top_w,
+            stroke_right_width: right_w,
+            stroke_bottom_width: bottom_w,
+            stroke_left_width: left_w,
+        })
+    };
+
+    // Stroke style: map border-style to dash array
+    let dash_array = match b.top.style {
+        CssBorderStyle::Dashed => Some(StrokeDashArray(vec![4.0, 4.0])),
+        CssBorderStyle::Dotted => Some(StrokeDashArray(vec![1.0, 1.0])),
+        _ => None,
+    };
+
+    let stroke_style = StrokeStyle {
+        stroke_align: StrokeAlign::Inside,
+        stroke_cap: StrokeCap::Butt,
+        stroke_join: StrokeJoin::Miter,
+        stroke_miter_limit: StrokeMiterLimit::default(),
+        stroke_dash_array: dash_array,
+    };
+
+    (strokes, stroke_width, stroke_style)
+}
+
+/// CSS effects (box-shadow, filter, backdrop-filter) → [`LayerEffects`].
+///
+/// Box shadows first (source order), then `filter` drop-shadows; the
+/// last `filter: blur()` and the last `backdrop-filter: blur()` win.
+/// Color-matrix filter functions (brightness, contrast, …) have no
+/// layer-effect equivalent and are dropped, as before.
+pub(super) fn effects_from(el: &StyledElement) -> LayerEffects {
+    let mut shadows = Vec::new();
+    let mut blur = None;
+    let mut backdrop_blur = None;
+
+    for s in &el.box_shadow {
+        let fe = FeShadow {
+            dx: s.offset_x,
+            dy: s.offset_y,
+            blur: s.blur,
+            spread: s.spread,
+            color: s.color,
+            active: true,
+        };
+        shadows.push(if s.inset {
+            FilterShadowEffect::InnerShadow(fe)
+        } else {
+            FilterShadowEffect::DropShadow(fe)
+        });
+    }
+
+    for f in &el.filter {
+        match f {
+            FilterFunction::Blur(px) => blur = Some(FeLayerBlur::from(*px)),
+            FilterFunction::DropShadow {
+                offset_x,
+                offset_y,
+                blur: shadow_blur,
+                color,
+            } => {
+                shadows.push(FilterShadowEffect::DropShadow(FeShadow {
+                    dx: *offset_x,
+                    dy: *offset_y,
+                    blur: *shadow_blur,
+                    spread: 0.0,
+                    color: *color,
+                    active: true,
+                }));
+            }
+            _ => {}
+        }
+    }
+
+    for f in &el.backdrop_filter {
+        if let FilterFunction::Blur(px) = f {
+            backdrop_blur = Some(FeBackdropBlur::from(*px));
+        }
+    }
+
+    LayerEffects {
+        blur,
+        backdrop_blur,
+        shadows,
+        glass: None,
+        noises: Vec::new(),
+    }
+}
+
+/// CSS `mix-blend-mode` → [`LayerBlendMode`]. `normal` is
+/// `PassThrough`, everything else wraps 1:1.
+pub(super) fn blend_mode_from(el: &StyledElement) -> LayerBlendMode {
+    match el.blend_mode {
+        BlendMode::Normal => LayerBlendMode::PassThrough,
+        mode => LayerBlendMode::Blend(mode),
     }
 }
 

--- a/crates/grida/src/import/html/from_styled.rs
+++ b/crates/grida/src/import/html/from_styled.rs
@@ -24,7 +24,7 @@ use crate::htmlcss::style::{
 use crate::htmlcss::types::AlignItems as CssAlignItems;
 use crate::htmlcss::types::{
     BorderStyle as CssBorderStyle, CssLength, Display, FlexDirection, FlexWrap, JustifyContent,
-    Position,
+    LineHeight as CssLineHeight, Position, TextAlignKeyword,
 };
 
 use super::CSSMargin;
@@ -457,6 +457,108 @@ pub(super) fn blend_mode_from(el: &StyledElement) -> LayerBlendMode {
         BlendMode::Normal => LayerBlendMode::PassThrough,
         mode => LayerBlendMode::Blend(mode),
     }
+}
+
+/// Text typography ([`TextStyleRec`]) and fill color from the record's
+/// inherited font/text properties. Shared by the text-span and
+/// attributed-text emitters.
+pub(super) fn text_style_from(el: &StyledElement) -> (TextStyleRec, Paints) {
+    let font = &el.font;
+    let mut text_style = TextStyleRec::from_font("system-ui", 16.0);
+
+    text_style.font_size = font.size;
+    text_style.font_weight = font.weight;
+
+    // First family: generic keywords keep their identity via
+    // `first_generic` (the Debug names mirror Stylo's generic enum,
+    // which the old code formatted directly); named families come
+    // through as-is. An empty family list keeps the default.
+    if let Some(generic) = font.first_generic {
+        text_style.font_family = format!("{:?}", generic);
+    } else if let Some(first) = font.families.first() {
+        text_style.font_family = first.clone();
+    }
+
+    text_style.font_style_italic = font.italic;
+
+    match font.line_height {
+        CssLineHeight::Normal => {}
+        CssLineHeight::Number(n) => {
+            text_style.line_height = TextLineHeight::Factor(n);
+        }
+        CssLineHeight::Px(px) => {
+            text_style.line_height = TextLineHeight::Fixed(px);
+        }
+    }
+
+    if font.letter_spacing != 0.0 {
+        text_style.letter_spacing = TextLetterSpacing::Fixed(font.letter_spacing);
+    }
+
+    if font.word_spacing != 0.0 {
+        text_style.word_spacing = TextWordSpacing::Fixed(font.word_spacing);
+    }
+
+    text_style.text_transform = font.text_transform;
+
+    // Decoration: line-through wins over underline wins over overline —
+    // the old bitflag priority. `currentcolor` decoration colors stay
+    // `None` in the record; fully-transparent ones fold to `None` too
+    // (the old css_color_to_cg behavior) so paint falls back to the
+    // text color.
+    let line = if font.decoration_line_through {
+        TextDecorationLine::LineThrough
+    } else if font.decoration_underline {
+        TextDecorationLine::Underline
+    } else if font.decoration_overline {
+        TextDecorationLine::Overline
+    } else {
+        TextDecorationLine::None
+    };
+    if !matches!(line, TextDecorationLine::None) {
+        let td_color = font.decoration_color.filter(|c| c.a != 0);
+        text_style.text_decoration = Some(TextDecorationRec {
+            text_decoration_line: line,
+            text_decoration_color: td_color,
+            text_decoration_style: Some(font.decoration_style),
+            text_decoration_skip_ink: None,
+            text_decoration_thickness: None,
+        });
+    }
+
+    let fills = Paints::new([solid(el.color)]);
+
+    (text_style, fills)
+}
+
+/// The authored `text-align` keyword → [`TextAlign`]. Logical
+/// `start`/`end` map to physical left/right unconditionally — the
+/// importer has never resolved them against `direction`, and the
+/// goldens pin that (see `FontProps::text_align_keyword`).
+pub(super) fn text_align_from(el: &StyledElement) -> TextAlign {
+    match el.font.text_align_keyword {
+        TextAlignKeyword::Start | TextAlignKeyword::Left => TextAlign::Left,
+        TextAlignKeyword::End | TextAlignKeyword::Right => TextAlign::Right,
+        TextAlignKeyword::Center => TextAlign::Center,
+        TextAlignKeyword::Justify => TextAlign::Justify,
+    }
+}
+
+/// Effects for text nodes: the element-level effects (box-shadow,
+/// filter, backdrop-filter) with `text-shadow` drop-shadows appended.
+pub(super) fn text_effects_from(el: &StyledElement) -> LayerEffects {
+    let mut base = effects_from(el);
+    base.shadows.extend(el.font.text_shadow.iter().map(|s| {
+        FilterShadowEffect::DropShadow(FeShadow {
+            dx: s.offset_x,
+            dy: s.offset_y,
+            blur: s.blur,
+            spread: 0.0,
+            color: s.color,
+            active: true,
+        })
+    }));
+    base
 }
 
 /// CSS margin → the importer's margin-surgery input. The record stores

--- a/crates/grida/src/import/html/from_styled.rs
+++ b/crates/grida/src/import/html/from_styled.rs
@@ -11,7 +11,7 @@
 //! `html_import_snapshot` golden corpus) exactly; where the record is
 //! richer than what the importer historically consumed (percent radii,
 //! `repeating` gradient flags, flex-basis, …), the extra information is
-//! deliberately dropped, matching the old `ComputedValues` walk.
+//! deliberately dropped, matching the old direct-Stylo walk.
 
 use crate::cg::prelude::*;
 use crate::node::schema::*;
@@ -98,7 +98,7 @@ pub(super) fn layout_child_from(el: &StyledElement) -> Option<LayoutChildStyle> 
     let grow = el.flex_grow;
     // The record maps `position: fixed` to `Position::Absolute` at
     // extraction (Stylo's `is_absolutely_positioned` covers both), so
-    // one variant check matches the old ComputedValues read.
+    // one variant check matches the old direct-Stylo read.
     let is_absolute = el.position == Position::Absolute;
     if grow > 0.0 || is_absolute {
         Some(LayoutChildStyle {

--- a/crates/grida/src/import/html/mod.rs
+++ b/crates/grida/src/import/html/mod.rs
@@ -15,7 +15,7 @@ use crate::node::schema::*;
 
 use crate::htmlcss::collect::styled_of;
 use crate::htmlcss::style::StyledElement;
-use crate::htmlcss::types::Display as CssDisplay;
+use crate::htmlcss::types::{Display as CssDisplay, Overflow as CssOverflow};
 
 use csscascade::adapter::{self, HtmlElement};
 use csscascade::dom::DemoNodeData;
@@ -24,13 +24,12 @@ use style::color::{AbsoluteColor, ColorSpace};
 use style::dom::TElement;
 use style::properties::ComputedValues;
 use style::values::generics::font::LineHeight;
-use style::values::specified::border::BorderStyle;
-use style::values::specified::position::{HorizontalPositionKeyword, VerticalPositionKeyword};
 use style::values::specified::text::TextDecorationLine as StyloTextDecorationLine;
 
 mod from_styled;
 use from_styled::{
-    dimensions_from, flex_container_from, layout_child_from, margin_from, size_from,
+    blend_mode_from, corner_radius_from, dimensions_from, effects_from, fills_from_background,
+    flex_container_from, layout_child_from, margin_from, size_from, strokes_from_border,
 };
 
 /// Parse an HTML string and convert it into a Grida [`SceneGraph`].
@@ -126,11 +125,11 @@ impl SceneBuilder {
         if has_text_children && all_children_inline && !is_structural {
             // All children are text or inline elements → emit as a single
             // Container (for box model) with an AttributedText child (for text).
-            let container_id = self.emit_container(style, &styled, parent);
+            let container_id = self.emit_container(&styled, parent);
             self.emit_attributed_text(element, style, &styled, Parent::NodeId(container_id));
         } else if has_element_children || has_text_children || is_structural {
             // Mixed content or structural element → Container with separate children.
-            let container_id = self.emit_container(style, &styled, parent);
+            let container_id = self.emit_container(&styled, parent);
             let container_parent = Parent::NodeId(container_id);
 
             // Emit inline text children
@@ -153,7 +152,7 @@ impl SceneBuilder {
             }
         } else {
             // Empty visual element → Rectangle
-            self.emit_rectangle(style, &styled, parent);
+            self.emit_rectangle(&styled, parent);
         }
     }
 
@@ -186,25 +185,20 @@ impl SceneBuilder {
         self.graph.append_child(Node::Container(wrapper), parent)
     }
 
-    fn emit_container(
-        &mut self,
-        style: &ComputedValues,
-        styled: &StyledElement,
-        parent: Parent,
-    ) -> NodeId {
+    fn emit_container(&mut self, styled: &StyledElement, parent: Parent) -> NodeId {
         let mut node = self.factory.create_container_node();
 
         // Display / layout mode, flex direction/wrap/alignment, gap
         flex_container_from(styled, &mut node.layout_container);
 
         // Opacity
-        node.opacity = style.get_effects().opacity;
+        node.opacity = styled.opacity;
 
         // Background → fills (solid color + gradients)
-        node.fills = css_background_to_fills(style);
+        node.fills = fills_from_background(styled);
 
         // Border radius
-        node.corner_radius = css_border_radius_to_cg(style);
+        node.corner_radius = corner_radius_from(styled);
 
         // Padding
         let padding = styled.padding;
@@ -217,21 +211,21 @@ impl SceneBuilder {
         }
 
         // Overflow → clip
-        let bx = style.get_box();
-        node.clip = bx.overflow_x != style::values::specified::box_::Overflow::Visible
-            || bx.overflow_y != style::values::specified::box_::Overflow::Visible;
+        node.clip =
+            styled.overflow_x != CssOverflow::Visible || styled.overflow_y != CssOverflow::Visible;
 
         // Borders → strokes + stroke_width
-        let (border_strokes, border_stroke_width, border_stroke_style) = css_border_to_cg(style);
+        let (border_strokes, border_stroke_width, border_stroke_style) =
+            strokes_from_border(styled);
         node.strokes = border_strokes;
         node.stroke_width = border_stroke_width;
         node.stroke_style = border_stroke_style;
 
         // Effects (box-shadow, filter, backdrop-filter)
-        node.effects = css_effects_to_cg(style);
+        node.effects = effects_from(styled);
 
         // Blend mode (mix-blend-mode)
-        node.blend_mode = css_blend_mode_to_cg(style);
+        node.blend_mode = blend_mode_from(styled);
 
         // Width / height / min / max dimensions
         dimensions_from(styled, &mut node.layout_dimensions);
@@ -409,12 +403,12 @@ impl SceneBuilder {
         }
     }
 
-    fn emit_rectangle(&mut self, style: &ComputedValues, styled: &StyledElement, parent: Parent) {
+    fn emit_rectangle(&mut self, styled: &StyledElement, parent: Parent) {
         let mut node = self.factory.create_rectangle_node();
 
-        node.fills = css_background_to_fills(style);
-        node.corner_radius = css_border_radius_to_cg(style);
-        node.opacity = style.get_effects().opacity;
+        node.fills = fills_from_background(styled);
+        node.corner_radius = corner_radius_from(styled);
+        node.opacity = styled.opacity;
 
         // CSS dimensions → node size
         node.size = size_from(styled);
@@ -423,16 +417,17 @@ impl SceneBuilder {
         node.layout_child = layout_child_from(styled);
 
         // Borders
-        let (border_strokes, border_stroke_width, border_stroke_style) = css_border_to_cg(style);
+        let (border_strokes, border_stroke_width, border_stroke_style) =
+            strokes_from_border(styled);
         node.strokes = border_strokes;
         node.stroke_width = border_stroke_width;
         node.stroke_style = border_stroke_style;
 
         // Effects (box-shadow, filter, backdrop-filter)
-        node.effects = css_effects_to_cg(style);
+        node.effects = effects_from(styled);
 
         // Blend mode (mix-blend-mode)
-        node.blend_mode = css_blend_mode_to_cg(style);
+        node.blend_mode = blend_mode_from(styled);
 
         // Margin → tree surgery (same pattern as emit_container)
         let margin = margin_from(styled);
@@ -475,32 +470,6 @@ fn abs_color_to_cg(color: &AbsoluteColor) -> CGColor {
     let b = (srgb.components.2.clamp(0.0, 1.0) * 255.0) as u8;
     let a = (srgb.alpha.clamp(0.0, 1.0) * 255.0) as u8;
     CGColor::from_rgba(r, g, b, a)
-}
-
-/// Extract border-radius from computed styles.
-fn css_border_radius_to_cg(style: &ComputedValues) -> RectangularCornerRadius {
-    let border = style.get_border();
-    let lp_to_px = |lp: &style::values::computed::NonNegativeLengthPercentage| -> f32 {
-        lp.0.to_length().map(|l| l.px()).unwrap_or(0.0)
-    };
-    RectangularCornerRadius {
-        tl: Radius {
-            rx: lp_to_px(&border.border_top_left_radius.0.width),
-            ry: lp_to_px(&border.border_top_left_radius.0.height),
-        },
-        tr: Radius {
-            rx: lp_to_px(&border.border_top_right_radius.0.width),
-            ry: lp_to_px(&border.border_top_right_radius.0.height),
-        },
-        br: Radius {
-            rx: lp_to_px(&border.border_bottom_right_radius.0.width),
-            ry: lp_to_px(&border.border_bottom_right_radius.0.height),
-        },
-        bl: Radius {
-            rx: lp_to_px(&border.border_bottom_left_radius.0.width),
-            ry: lp_to_px(&border.border_bottom_left_radius.0.height),
-        },
-    }
 }
 
 /// Parsed CSS margin with per-edge auto tracking.
@@ -663,340 +632,6 @@ fn css_text_align_to_cg(align: style::values::computed::TextAlign) -> TextAlign 
         TextAlignKeyword::Center | TextAlignKeyword::MozCenter => TextAlign::Center,
         TextAlignKeyword::Justify => TextAlign::Justify,
     }
-}
-
-/// Convert CSS background (color + background-image gradients) to fill paints.
-fn css_background_to_fills(style: &ComputedValues) -> Paints {
-    use style::values::generics::image::{GenericGradient, GenericImage};
-
-    let bg = style.get_background();
-    let mut paints: Vec<Paint> = Vec::new();
-
-    // 1. Background color (bottom layer)
-    if let Some(cg_color) = css_color_to_cg(&bg.background_color) {
-        paints.push(Paint::Solid(SolidPaint {
-            color: cg_color,
-            blend_mode: BlendMode::default(),
-            active: true,
-        }));
-    }
-
-    // 2. Background images (gradient layers on top)
-    for image in bg.background_image.0.iter() {
-        if let GenericImage::Gradient(gradient) = image {
-            match gradient.as_ref() {
-                GenericGradient::Linear {
-                    direction, items, ..
-                } => {
-                    let stops = gradient_items_to_stops(items);
-                    if stops.is_empty() {
-                        continue;
-                    }
-                    let (xy1, xy2) = line_direction_to_alignment(direction);
-                    paints.push(Paint::LinearGradient(LinearGradientPaint {
-                        active: true,
-                        xy1,
-                        xy2,
-                        stops,
-                        ..Default::default()
-                    }));
-                }
-                GenericGradient::Radial { items, .. } => {
-                    let stops = gradient_items_to_stops(items);
-                    if stops.is_empty() {
-                        continue;
-                    }
-                    paints.push(Paint::RadialGradient(RadialGradientPaint::from_stops(
-                        stops,
-                    )));
-                }
-                GenericGradient::Conic { items, .. } => {
-                    let stops = conic_gradient_items_to_stops(items);
-                    if stops.is_empty() {
-                        continue;
-                    }
-                    paints.push(Paint::SweepGradient(SweepGradientPaint {
-                        active: true,
-                        stops,
-                        ..Default::default()
-                    }));
-                }
-            }
-        }
-    }
-
-    if paints.is_empty() {
-        Paints::default()
-    } else {
-        Paints::new(paints)
-    }
-}
-
-/// Convert Stylo gradient items (color stops + hints) to CG GradientStops.
-fn gradient_items_to_stops(
-    items: &[style::values::generics::image::GenericGradientItem<
-        style::values::computed::Color,
-        style::values::computed::LengthPercentage,
-    >],
-) -> Vec<GradientStop> {
-    use style::values::generics::image::GenericGradientItem;
-
-    // First pass: collect stops with known positions
-    let mut raw: Vec<(Option<f32>, CGColor)> = Vec::new();
-    for item in items {
-        match item {
-            GenericGradientItem::SimpleColorStop(color) => {
-                let cg = css_color_to_cg(color).unwrap_or_else(|| CGColor::from_rgba(0, 0, 0, 0));
-                raw.push((None, cg));
-            }
-            GenericGradientItem::ComplexColorStop { color, position } => {
-                let offset = position.to_percentage().map(|p| p.0).or_else(|| {
-                    position.to_length().map(|_l| {
-                        // For absolute lengths in gradients, we can't resolve without
-                        // knowing the gradient line length. Treat as 0.
-                        0.0
-                    })
-                });
-                let cg = css_color_to_cg(color).unwrap_or_else(|| CGColor::from_rgba(0, 0, 0, 0));
-                raw.push((offset, cg));
-            }
-            GenericGradientItem::InterpolationHint(_) => {
-                // Interpolation hints change the midpoint; skip for now.
-            }
-        }
-    }
-
-    if raw.is_empty() {
-        return Vec::new();
-    }
-
-    // Auto-distribute positions for stops without explicit offsets.
-    // First stop defaults to 0.0, last to 1.0.
-    let n = raw.len();
-    if n > 0 {
-        if raw[0].0.is_none() {
-            raw[0].0 = Some(0.0);
-        }
-        if raw[n - 1].0.is_none() {
-            raw[n - 1].0 = Some(1.0);
-        }
-    }
-
-    // Fill gaps: evenly distribute between known positions
-    let mut i = 0;
-    while i < n {
-        if raw[i].0.is_some() {
-            i += 1;
-            continue;
-        }
-        // Find the next stop with a known position
-        let start = i - 1;
-        let mut end = i + 1;
-        while end < n && raw[end].0.is_none() {
-            end += 1;
-        }
-        let start_offset = raw[start].0.unwrap();
-        let end_offset = raw[end].0.unwrap();
-        let count = (end - start) as f32;
-        #[allow(clippy::needless_range_loop)]
-        for j in (start + 1)..end {
-            let t = (j - start) as f32 / count;
-            raw[j].0 = Some(start_offset + t * (end_offset - start_offset));
-        }
-        i = end + 1;
-    }
-
-    raw.into_iter()
-        .map(|(offset, color)| GradientStop {
-            offset: offset.unwrap_or(0.0),
-            color,
-        })
-        .collect()
-}
-
-/// Convert conic-gradient items (color stops with angle/percentage positions) to CG GradientStops.
-fn conic_gradient_items_to_stops(
-    items: &[style::values::generics::image::GenericGradientItem<
-        style::values::computed::Color,
-        style::values::computed::AngleOrPercentage,
-    >],
-) -> Vec<GradientStop> {
-    use style::values::generics::image::GenericGradientItem;
-
-    let mut raw: Vec<(Option<f32>, CGColor)> = Vec::new();
-    for item in items {
-        match item {
-            GenericGradientItem::SimpleColorStop(color) => {
-                let cg = css_color_to_cg(color).unwrap_or_else(|| CGColor::from_rgba(0, 0, 0, 0));
-                raw.push((None, cg));
-            }
-            GenericGradientItem::ComplexColorStop { color, position } => {
-                // Conic gradient positions are in angles or percentages (0–100% maps to 0–360deg)
-                use style::values::computed::AngleOrPercentage;
-                let offset = match position {
-                    AngleOrPercentage::Percentage(p) => Some(p.0),
-                    AngleOrPercentage::Angle(a) => Some(a.degrees() / 360.0),
-                };
-                let cg = css_color_to_cg(color).unwrap_or_else(|| CGColor::from_rgba(0, 0, 0, 0));
-                raw.push((offset, cg));
-            }
-            GenericGradientItem::InterpolationHint(_) => {}
-        }
-    }
-
-    if raw.is_empty() {
-        return Vec::new();
-    }
-
-    // Auto-distribute (same logic as linear/radial)
-    let n = raw.len();
-    if raw[0].0.is_none() {
-        raw[0].0 = Some(0.0);
-    }
-    if raw[n - 1].0.is_none() {
-        raw[n - 1].0 = Some(1.0);
-    }
-
-    let mut i = 0;
-    while i < n {
-        if raw[i].0.is_some() {
-            i += 1;
-            continue;
-        }
-        let start = i - 1;
-        let mut end = i + 1;
-        while end < n && raw[end].0.is_none() {
-            end += 1;
-        }
-        let start_offset = raw[start].0.unwrap();
-        let end_offset = raw[end].0.unwrap();
-        let count = (end - start) as f32;
-        #[allow(clippy::needless_range_loop)]
-        for j in (start + 1)..end {
-            let t = (j - start) as f32 / count;
-            raw[j].0 = Some(start_offset + t * (end_offset - start_offset));
-        }
-        i = end + 1;
-    }
-
-    raw.into_iter()
-        .map(|(offset, color)| GradientStop {
-            offset: offset.unwrap_or(0.0),
-            color,
-        })
-        .collect()
-}
-
-/// Convert CSS linear-gradient direction to IR Alignment endpoints.
-///
-/// CSS gradient angles: 0deg = to top, 90deg = to right, 180deg = to bottom.
-/// IR Alignment: (-1,-1) = top-left, (0,0) = center, (1,1) = bottom-right.
-fn line_direction_to_alignment(
-    direction: &style::values::computed::image::LineDirection,
-) -> (Alignment, Alignment) {
-    use style::values::computed::image::LineDirection;
-
-    match direction {
-        LineDirection::Angle(angle) => {
-            // CSS: 0deg = to top, clockwise. Convert to math angle.
-            let rad = angle.radians();
-            let sin = rad.sin();
-            let cos = rad.cos();
-            // CSS gradient line: from (-sin, cos) to (sin, -cos) in NDC
-            let xy1 = Alignment(-sin, cos);
-            let xy2 = Alignment(sin, -cos);
-            (xy1, xy2)
-        }
-        LineDirection::Vertical(v) => match v {
-            VerticalPositionKeyword::Top => (Alignment::BOTTOM_CENTER, Alignment::TOP_CENTER),
-            VerticalPositionKeyword::Bottom => (Alignment::TOP_CENTER, Alignment::BOTTOM_CENTER),
-        },
-        LineDirection::Horizontal(h) => match h {
-            HorizontalPositionKeyword::Left => (Alignment::CENTER_RIGHT, Alignment::CENTER_LEFT),
-            HorizontalPositionKeyword::Right => (Alignment::CENTER_LEFT, Alignment::CENTER_RIGHT),
-        },
-        LineDirection::Corner(h, v) => {
-            let x1 = match h {
-                HorizontalPositionKeyword::Left => 1.0,
-                HorizontalPositionKeyword::Right => -1.0,
-            };
-            let y1 = match v {
-                VerticalPositionKeyword::Top => 1.0,
-                VerticalPositionKeyword::Bottom => -1.0,
-            };
-            (Alignment(x1, y1), Alignment(-x1, -y1))
-        }
-    }
-}
-
-/// Convert CSS border properties to CG strokes, stroke width, and stroke style.
-fn css_border_to_cg(style: &ComputedValues) -> (Paints, StrokeWidth, StrokeStyle) {
-    let border = style.get_border();
-
-    // Stylo stores the unresolved `medium` default (3px) in `BorderSideWidth`
-    // even when `border-style` is `none`/`hidden`. Treat those as zero-width.
-    use style::values::specified::border::BorderStyle as BS;
-    let width_for = |w: &style::values::computed::BorderSideWidth, s: BS| -> f32 {
-        match s {
-            BS::None | BS::Hidden => 0.0,
-            _ => w.0.to_f32_px(),
-        }
-    };
-    let top_w = width_for(&border.border_top_width, border.border_top_style);
-    let right_w = width_for(&border.border_right_width, border.border_right_style);
-    let bottom_w = width_for(&border.border_bottom_width, border.border_bottom_style);
-    let left_w = width_for(&border.border_left_width, border.border_left_style);
-
-    let has_border = top_w > 0.0 || right_w > 0.0 || bottom_w > 0.0 || left_w > 0.0;
-    if !has_border {
-        return (Paints::default(), StrokeWidth::None, StrokeStyle::default());
-    }
-
-    // Use the top border color as the primary stroke color (most common single-color case).
-    // For per-side colors, we use the first visible border side.
-    let border_color = css_color_to_cg(&border.border_top_color)
-        .or_else(|| css_color_to_cg(&border.border_right_color))
-        .or_else(|| css_color_to_cg(&border.border_bottom_color))
-        .or_else(|| css_color_to_cg(&border.border_left_color));
-
-    let strokes = match border_color {
-        Some(color) => Paints::new([Paint::Solid(SolidPaint {
-            color,
-            blend_mode: BlendMode::default(),
-            active: true,
-        })]),
-        None => return (Paints::default(), StrokeWidth::None, StrokeStyle::default()),
-    };
-
-    // Stroke width: use rectangular if sides differ, uniform otherwise
-    let stroke_width = if top_w == right_w && right_w == bottom_w && bottom_w == left_w {
-        StrokeWidth::Uniform(top_w)
-    } else {
-        StrokeWidth::Rectangular(RectangularStrokeWidth {
-            stroke_top_width: top_w,
-            stroke_right_width: right_w,
-            stroke_bottom_width: bottom_w,
-            stroke_left_width: left_w,
-        })
-    };
-
-    // Stroke style: map border-style to dash array
-    let top_style = border.border_top_style;
-    let dash_array = match top_style {
-        BorderStyle::Dashed => Some(StrokeDashArray(vec![4.0, 4.0])),
-        BorderStyle::Dotted => Some(StrokeDashArray(vec![1.0, 1.0])),
-        _ => None,
-    };
-
-    let stroke_style = StrokeStyle {
-        stroke_align: StrokeAlign::Inside,
-        stroke_cap: StrokeCap::Butt,
-        stroke_join: StrokeJoin::Miter,
-        stroke_miter_limit: StrokeMiterLimit::default(),
-        stroke_dash_array: dash_array,
-    };
-
-    (strokes, stroke_width, stroke_style)
 }
 
 /// Convert CSS effects (box-shadow, filter, backdrop-filter) to CG LayerEffects.

--- a/crates/grida/src/import/html/mod.rs
+++ b/crates/grida/src/import/html/mod.rs
@@ -13,19 +13,25 @@ use crate::node::factory::NodeFactory;
 use crate::node::scene_graph::{Parent, SceneGraph};
 use crate::node::schema::*;
 
+use crate::htmlcss::collect::styled_of;
+use crate::htmlcss::style::StyledElement;
+use crate::htmlcss::types::Display as CssDisplay;
+
 use csscascade::adapter::{self, HtmlElement};
 use csscascade::dom::DemoNodeData;
 
 use style::color::{AbsoluteColor, ColorSpace};
 use style::dom::TElement;
-use style::properties::longhands;
 use style::properties::ComputedValues;
 use style::values::generics::font::LineHeight;
-use style::values::generics::length::{GenericMaxSize, GenericSize, LengthPercentageOrNormal};
-use style::values::specified::align::AlignFlags;
 use style::values::specified::border::BorderStyle;
 use style::values::specified::position::{HorizontalPositionKeyword, VerticalPositionKeyword};
 use style::values::specified::text::TextDecorationLine as StyloTextDecorationLine;
+
+mod from_styled;
+use from_styled::{
+    dimensions_from, flex_container_from, layout_child_from, margin_from, size_from,
+};
 
 /// Parse an HTML string and convert it into a Grida [`SceneGraph`].
 ///
@@ -68,18 +74,23 @@ impl SceneBuilder {
 
     fn build_element(&mut self, element: HtmlElement, parent: Parent) {
         let dom = adapter::dom();
+        // Shared per-element style record (htmlcss seam, gridaco/nothing#30).
+        let Some(styled) = styled_of(element) else {
+            return;
+        };
+
+        // Skip display:none elements entirely
+        if styled.display == CssDisplay::None {
+            return;
+        }
+
+        // Transitional: Stylo reads for the not-yet-rewired paint/text
+        // mappings. Deleted once every emitter consumes `styled`.
         let data = element.borrow_data();
         let Some(data) = &data else {
             return;
         };
-
         let style = data.styles.primary();
-
-        // Skip display:none elements entirely
-        let display = style.clone_display();
-        if display.is_none() {
-            return;
-        }
 
         let tag = element.local_name_string();
 
@@ -94,17 +105,15 @@ impl SceneBuilder {
 
         let is_structural = matches!(tag.as_str(), "html" | "body");
 
-        // Check if all element children are inline (display: inline).
-        // When true and we have text, we can merge everything into AttributedText.
+        // Check if all element children are inline (outer display type
+        // `inline` — includes inline-block, inline-flex, …). When true
+        // and we have text, we can merge everything into AttributedText.
         let all_children_inline = has_element_children && {
             let mut all_inline = true;
             let mut child = element.first_element_child();
             while let Some(c) = child {
-                let c_data = c.borrow_data();
-                if let Some(c_data) = &c_data {
-                    let c_display = c_data.styles.primary().clone_display();
-                    if c_display.outside() != style::values::specified::box_::DisplayOutside::Inline
-                    {
+                if let Some(child_styled) = styled_of(c) {
+                    if !child_styled.inline_outside {
                         all_inline = false;
                         break;
                     }
@@ -117,11 +126,11 @@ impl SceneBuilder {
         if has_text_children && all_children_inline && !is_structural {
             // All children are text or inline elements → emit as a single
             // Container (for box model) with an AttributedText child (for text).
-            let container_id = self.emit_container(style, &display, parent);
-            self.emit_attributed_text(element, style, Parent::NodeId(container_id));
+            let container_id = self.emit_container(style, &styled, parent);
+            self.emit_attributed_text(element, style, &styled, Parent::NodeId(container_id));
         } else if has_element_children || has_text_children || is_structural {
             // Mixed content or structural element → Container with separate children.
-            let container_id = self.emit_container(style, &display, parent);
+            let container_id = self.emit_container(style, &styled, parent);
             let container_parent = Parent::NodeId(container_id);
 
             // Emit inline text children
@@ -131,7 +140,7 @@ impl SceneBuilder {
                 if let DemoNodeData::Text(text) = &child_node.data {
                     let trimmed = text.trim();
                     if !trimmed.is_empty() {
-                        self.emit_text_span(trimmed, style, container_parent.clone());
+                        self.emit_text_span(trimmed, style, &styled, container_parent.clone());
                     }
                 }
             }
@@ -144,7 +153,7 @@ impl SceneBuilder {
             }
         } else {
             // Empty visual element → Rectangle
-            self.emit_rectangle(style, parent);
+            self.emit_rectangle(style, &styled, parent);
         }
     }
 
@@ -180,70 +189,13 @@ impl SceneBuilder {
     fn emit_container(
         &mut self,
         style: &ComputedValues,
-        display: &style::values::computed::Display,
+        styled: &StyledElement,
         parent: Parent,
     ) -> NodeId {
-        use longhands::flex_direction::computed_value::T as FlexDir;
-        use longhands::flex_wrap::computed_value::T as FlexWr;
-
-        let is_flex = display.inside() == style::values::specified::box_::DisplayInside::Flex;
         let mut node = self.factory.create_container_node();
 
-        // Display / layout mode
-        if is_flex {
-            node.layout_container.layout_mode = LayoutMode::Flex;
-
-            node.layout_container.layout_direction = match style.clone_flex_direction() {
-                FlexDir::Row | FlexDir::RowReverse => Axis::Horizontal,
-                FlexDir::Column | FlexDir::ColumnReverse => Axis::Vertical,
-            };
-
-            node.layout_container.layout_wrap = Some(match style.clone_flex_wrap() {
-                FlexWr::Nowrap => LayoutWrap::NoWrap,
-                FlexWr::Wrap | FlexWr::WrapReverse => LayoutWrap::Wrap,
-            });
-
-            // align-items → cross axis alignment
-            let align_items = style.clone_align_items();
-            let ai_flags = align_items.0.value();
-            node.layout_container.layout_cross_axis_alignment = match ai_flags {
-                f if f == AlignFlags::CENTER => Some(CrossAxisAlignment::Center),
-                f if f == AlignFlags::FLEX_START || f == AlignFlags::START => {
-                    Some(CrossAxisAlignment::Start)
-                }
-                f if f == AlignFlags::FLEX_END || f == AlignFlags::END => {
-                    Some(CrossAxisAlignment::End)
-                }
-                f if f == AlignFlags::STRETCH => Some(CrossAxisAlignment::Stretch),
-                _ => None,
-            };
-
-            // justify-content → main axis alignment
-            let jc = style.clone_justify_content();
-            let jc_flags = jc.primary().value();
-            node.layout_container.layout_main_axis_alignment = match jc_flags {
-                f if f == AlignFlags::CENTER => Some(MainAxisAlignment::Center),
-                f if f == AlignFlags::FLEX_START || f == AlignFlags::START => {
-                    Some(MainAxisAlignment::Start)
-                }
-                f if f == AlignFlags::FLEX_END || f == AlignFlags::END => {
-                    Some(MainAxisAlignment::End)
-                }
-                f if f == AlignFlags::SPACE_BETWEEN => Some(MainAxisAlignment::SpaceBetween),
-                f if f == AlignFlags::SPACE_AROUND => Some(MainAxisAlignment::SpaceAround),
-                f if f == AlignFlags::SPACE_EVENLY => Some(MainAxisAlignment::SpaceEvenly),
-                f if f == AlignFlags::STRETCH => Some(MainAxisAlignment::Stretch),
-                _ => None,
-            };
-        } else {
-            // CSS `display: block` → map to Flex column.
-            // The IR's `LayoutMode::Normal` maps to taffy `Display::Block`, which
-            // causes children of a flex parent to stretch to 100% width (block
-            // intrinsic sizing). Using Flex column instead gives correct sizing
-            // when these containers are nested inside flex parents.
-            node.layout_container.layout_mode = LayoutMode::Flex;
-            node.layout_container.layout_direction = Axis::Vertical;
-        }
+        // Display / layout mode, flex direction/wrap/alignment, gap
+        flex_container_from(styled, &mut node.layout_container);
 
         // Opacity
         node.opacity = style.get_effects().opacity;
@@ -255,38 +207,13 @@ impl SceneBuilder {
         node.corner_radius = css_border_radius_to_cg(style);
 
         // Padding
-        let padding = css_padding_to_cg(style);
+        let padding = styled.padding;
         if padding.top != 0.0
             || padding.right != 0.0
             || padding.bottom != 0.0
             || padding.left != 0.0
         {
-            node.layout_container.layout_padding = Some(EdgeInsets {
-                top: padding.top,
-                right: padding.right,
-                bottom: padding.bottom,
-                left: padding.left,
-            });
-        }
-
-        // Gap (for flex containers)
-        // CSS column-gap = inline-axis gap, row-gap = block-axis gap.
-        // For flex-direction: row, column-gap is the main-axis gap.
-        // For flex-direction: column, row-gap is the main-axis gap.
-        if is_flex {
-            let pos = style.get_position();
-            let rg = gap_to_px(&pos.row_gap);
-            let cg = gap_to_px(&pos.column_gap);
-            if rg != 0.0 || cg != 0.0 {
-                let (main_gap, cross_gap) = match style.clone_flex_direction() {
-                    FlexDir::Row | FlexDir::RowReverse => (cg, rg),
-                    FlexDir::Column | FlexDir::ColumnReverse => (rg, cg),
-                };
-                node.layout_container.layout_gap = Some(LayoutGap {
-                    main_axis_gap: main_gap,
-                    cross_axis_gap: cross_gap,
-                });
-            }
+            node.layout_container.layout_padding = Some(padding);
         }
 
         // Overflow → clip
@@ -307,16 +234,16 @@ impl SceneBuilder {
         node.blend_mode = css_blend_mode_to_cg(style);
 
         // Width / height / min / max dimensions
-        css_dimensions_to_cg(style, &mut node.layout_dimensions);
+        dimensions_from(styled, &mut node.layout_dimensions);
 
         // Flex child properties (for nested containers inside flex parents)
-        node.layout_child = css_flex_child_to_cg(style);
+        node.layout_child = layout_child_from(styled);
 
         // Margin → tree surgery
         // Fixed positive margins are absorbed into the container's own padding when
         // the container has no visual properties (fills, borders) that would bleed
         // into the margin zone. Otherwise, a separate wrapper is created.
-        let margin = css_margin_to_cg(style);
+        let margin = margin_from(styled);
         if !margin.is_zero() && !margin.has_any_auto() && !margin.has_any_negative() {
             let has_visuals = !node.fills.is_empty() || !node.strokes.is_empty();
             if has_visuals {
@@ -345,7 +272,13 @@ impl SceneBuilder {
         }
     }
 
-    fn emit_text_span(&mut self, text: &str, style: &ComputedValues, parent: Parent) {
+    fn emit_text_span(
+        &mut self,
+        text: &str,
+        style: &ComputedValues,
+        styled: &StyledElement,
+        parent: Parent,
+    ) {
         let mut node = self.factory.create_text_span_node();
         node.text = text.to_string();
 
@@ -357,10 +290,9 @@ impl SceneBuilder {
         node.effects = css_text_shadow_to_effects(style);
         node.blend_mode = css_blend_mode_to_cg(style);
 
-        let flex_grow = style.clone_flex_grow();
-        if flex_grow.0 > 0.0 {
+        if styled.flex_grow > 0.0 {
             node.layout_child = Some(LayoutChildStyle {
-                layout_grow: flex_grow.0,
+                layout_grow: styled.flex_grow,
                 layout_positioning: LayoutPositioning::Auto,
             });
         }
@@ -378,6 +310,7 @@ impl SceneBuilder {
         &mut self,
         element: HtmlElement,
         style: &ComputedValues,
+        styled: &StyledElement,
         parent: Parent,
     ) {
         let dom = adapter::dom();
@@ -423,7 +356,7 @@ impl SceneBuilder {
             transform: Default::default(),
             width: None,
             height: None,
-            layout_child: css_flex_child_to_cg(style),
+            layout_child: layout_child_from(styled),
             attributed_string: attr_string,
             default_style,
             text_align: css_text_align_to_cg(style.get_inherited_text().text_align),
@@ -476,7 +409,7 @@ impl SceneBuilder {
         }
     }
 
-    fn emit_rectangle(&mut self, style: &ComputedValues, parent: Parent) {
+    fn emit_rectangle(&mut self, style: &ComputedValues, styled: &StyledElement, parent: Parent) {
         let mut node = self.factory.create_rectangle_node();
 
         node.fills = css_background_to_fills(style);
@@ -484,10 +417,10 @@ impl SceneBuilder {
         node.opacity = style.get_effects().opacity;
 
         // CSS dimensions → node size
-        node.size = css_size_to_cg(style);
+        node.size = size_from(styled);
 
         // Flex child properties (grow, positioning)
-        node.layout_child = css_flex_child_to_cg(style);
+        node.layout_child = layout_child_from(styled);
 
         // Borders
         let (border_strokes, border_stroke_width, border_stroke_style) = css_border_to_cg(style);
@@ -502,7 +435,7 @@ impl SceneBuilder {
         node.blend_mode = css_blend_mode_to_cg(style);
 
         // Margin → tree surgery (same pattern as emit_container)
-        let margin = css_margin_to_cg(style);
+        let margin = margin_from(styled);
         if !margin.is_zero() && !margin.has_any_auto() && !margin.has_any_negative() {
             let layout_child = node.layout_child.take();
             let wrapper_id = self.wrap_with_margin_padding(&margin, layout_child, parent);
@@ -570,26 +503,6 @@ fn css_border_radius_to_cg(style: &ComputedValues) -> RectangularCornerRadius {
     }
 }
 
-struct CSSPadding {
-    top: f32,
-    right: f32,
-    bottom: f32,
-    left: f32,
-}
-
-fn css_padding_to_cg(style: &ComputedValues) -> CSSPadding {
-    let p = style.get_padding();
-    let lp_to_px = |lp: &style::values::computed::NonNegativeLengthPercentage| -> f32 {
-        lp.0.to_length().map(|l| l.px()).unwrap_or(0.0)
-    };
-    CSSPadding {
-        top: lp_to_px(&p.padding_top),
-        right: lp_to_px(&p.padding_right),
-        bottom: lp_to_px(&p.padding_bottom),
-        left: lp_to_px(&p.padding_left),
-    }
-}
-
 /// Parsed CSS margin with per-edge auto tracking.
 struct CSSMargin {
     top: f32,
@@ -620,37 +533,6 @@ impl CSSMargin {
 
     fn has_any_negative(&self) -> bool {
         self.top < 0.0 || self.right < 0.0 || self.bottom < 0.0 || self.left < 0.0
-    }
-}
-
-fn css_margin_to_cg(style: &ComputedValues) -> CSSMargin {
-    // Stylo exposes margin fields as `computed::Margin` (GenericMargin<LengthPercentage>).
-    // Variants: Auto | LengthPercentage(lp) | AnchorSizeFunction (CSS anchoring, ignored).
-    fn extract(v: style::values::computed::Margin) -> (f32, bool) {
-        if v.is_auto() {
-            return (0.0, true);
-        }
-        match v {
-            style::values::computed::Margin::LengthPercentage(lp) => {
-                (lp.to_length().map(|l| l.px()).unwrap_or(0.0), false)
-            }
-            _ => (0.0, false),
-        }
-    }
-
-    let (top, top_auto) = extract(style.clone_margin_top());
-    let (right, right_auto) = extract(style.clone_margin_right());
-    let (bottom, bottom_auto) = extract(style.clone_margin_bottom());
-    let (left, left_auto) = extract(style.clone_margin_left());
-    CSSMargin {
-        top,
-        right,
-        bottom,
-        left,
-        top_auto,
-        right_auto,
-        bottom_auto,
-        left_auto,
     }
 }
 
@@ -766,56 +648,6 @@ fn css_text_style_to_cg(style: &ComputedValues) -> (TextStyleRec, Paints) {
     })]);
 
     (text_style, fills)
-}
-
-/// Convert CSS gap value to pixels. Returns 0 for `normal`.
-fn gap_to_px(gap: &style::values::computed::length::NonNegativeLengthPercentageOrNormal) -> f32 {
-    match gap {
-        LengthPercentageOrNormal::Normal => 0.0,
-        LengthPercentageOrNormal::LengthPercentage(lp) => {
-            lp.0.to_length().map(|l| l.px()).unwrap_or(0.0)
-        }
-    }
-}
-
-/// Extract flex-child properties (flex-grow, positioning) from CSS computed values.
-/// Returns `None` when all values are at their defaults (grow=0, position=static/relative).
-fn css_flex_child_to_cg(style: &ComputedValues) -> Option<LayoutChildStyle> {
-    let grow = style.clone_flex_grow().0;
-    let is_absolute = style.get_box().clone_position().is_absolutely_positioned();
-    let positioning = if is_absolute {
-        LayoutPositioning::Absolute
-    } else {
-        LayoutPositioning::Auto
-    };
-
-    if grow > 0.0 || is_absolute {
-        Some(LayoutChildStyle {
-            layout_grow: grow,
-            layout_positioning: positioning,
-        })
-    } else {
-        None
-    }
-}
-
-/// Extract CSS width/height into a Size for leaf nodes (Rectangle, etc.).
-/// Returns 0×0 when dimensions are `auto` — unlike the design-tool convention
-/// (100×100 default), HTML leaf elements have no intrinsic size.
-fn css_size_to_cg(style: &ComputedValues) -> Size {
-    let pos = style.get_position();
-    let w = match &pos.width {
-        GenericSize::LengthPercentage(lp) => lp.0.to_length().map(|l| l.px()).unwrap_or(0.0),
-        _ => 0.0,
-    };
-    let h = match &pos.height {
-        GenericSize::LengthPercentage(lp) => lp.0.to_length().map(|l| l.px()).unwrap_or(0.0),
-        _ => 0.0,
-    };
-    Size {
-        width: w,
-        height: h,
-    }
 }
 
 /// Map CSS text-align to CG TextAlign.
@@ -1297,71 +1129,6 @@ fn css_text_decoration_style_to_cg(style: &ComputedValues) -> Option<TextDecorat
         TDS::Dashed => Some(TextDecorationStyle::Dashed),
         TDS::Wavy => Some(TextDecorationStyle::Wavy),
         _ => None,
-    }
-}
-
-/// Map CSS width/height/min/max dimensions to LayoutDimensionStyle.
-fn css_dimensions_to_cg(style: &ComputedValues, dims: &mut LayoutDimensionStyle) {
-    let pos = style.get_position();
-
-    // width
-    match &pos.width {
-        GenericSize::LengthPercentage(lp) => {
-            if let Some(len) = lp.0.to_length() {
-                dims.layout_target_width = Some(len.px());
-            }
-        }
-        GenericSize::Auto => {
-            dims.layout_target_width = None;
-        }
-        _ => {}
-    }
-
-    // height
-    match &pos.height {
-        GenericSize::LengthPercentage(lp) => {
-            if let Some(len) = lp.0.to_length() {
-                dims.layout_target_height = Some(len.px());
-            }
-        }
-        GenericSize::Auto => {
-            dims.layout_target_height = None;
-        }
-        _ => {}
-    }
-
-    // min-width
-    if let GenericSize::LengthPercentage(lp) = &pos.min_width {
-        if let Some(len) = lp.0.to_length() {
-            let px = len.px();
-            if px > 0.0 {
-                dims.layout_min_width = Some(px);
-            }
-        }
-    }
-
-    // min-height
-    if let GenericSize::LengthPercentage(lp) = &pos.min_height {
-        if let Some(len) = lp.0.to_length() {
-            let px = len.px();
-            if px > 0.0 {
-                dims.layout_min_height = Some(px);
-            }
-        }
-    }
-
-    // max-width
-    if let GenericMaxSize::LengthPercentage(lp) = &pos.max_width {
-        if let Some(len) = lp.0.to_length() {
-            dims.layout_max_width = Some(len.px());
-        }
-    }
-
-    // max-height
-    if let GenericMaxSize::LengthPercentage(lp) = &pos.max_height {
-        if let Some(len) = lp.0.to_length() {
-            dims.layout_max_height = Some(len.px());
-        }
     }
 }
 

--- a/crates/grida/src/import/html/mod.rs
+++ b/crates/grida/src/import/html/mod.rs
@@ -14,14 +14,12 @@ use crate::node::scene_graph::{Parent, SceneGraph};
 use crate::node::schema::*;
 
 use csscascade::adapter::{self, HtmlElement};
-use csscascade::cascade::CascadeDriver;
-use csscascade::dom::{DemoDom, DemoNodeData};
+use csscascade::dom::DemoNodeData;
 
 use style::color::{AbsoluteColor, ColorSpace};
 use style::dom::TElement;
 use style::properties::longhands;
 use style::properties::ComputedValues;
-use style::thread_state::{self, ThreadState};
 use style::values::generics::font::LineHeight;
 use style::values::generics::length::{GenericMaxSize, GenericSize, LengthPercentageOrNormal};
 use style::values::specified::align::AlignFlags;
@@ -39,23 +37,10 @@ use style::values::specified::text::TextDecorationLine as StyloTextDecorationLin
 /// and is **not thread-safe**. Concurrent calls will race on the shared state.
 /// Callers must serialize access externally (e.g. via a mutex).
 pub fn from_html_str(html: &str) -> Result<SceneGraph, String> {
-    // Ensure Stylo thread state is initialized (idempotent after first call).
-    thread_state::initialize(ThreadState::LAYOUT);
+    // Parse + cascade via the shared front-end (htmlcss::frontend).
+    let document = crate::htmlcss::frontend::parse_and_style(html)?;
 
-    // 1. Parse HTML into arena DOM
-    let dom =
-        DemoDom::parse_from_bytes(html.as_bytes()).map_err(|e| format!("HTML parse error: {e}"))?;
-
-    // 2. Build cascade driver (collects <style> blocks, builds UA + author sheets)
-    let mut driver = CascadeDriver::new(&dom);
-
-    // 3. Install DOM into global slot
-    let document = adapter::bootstrap_dom(dom);
-
-    // 4. Flush stylist + resolve all styles
-    driver.flush(document);
-    let _styled_count = driver.style_document(document);
-    // 5. Build scene graph from styled DOM
+    // Build scene graph from styled DOM
     let mut builder = SceneBuilder::new();
     if let Some(root) = document.root_element() {
         builder.build_element(root, Parent::Root);

--- a/crates/grida/src/import/html/mod.rs
+++ b/crates/grida/src/import/html/mod.rs
@@ -20,16 +20,11 @@ use crate::htmlcss::types::{Display as CssDisplay, Overflow as CssOverflow};
 use csscascade::adapter::{self, HtmlElement};
 use csscascade::dom::DemoNodeData;
 
-use style::color::{AbsoluteColor, ColorSpace};
-use style::dom::TElement;
-use style::properties::ComputedValues;
-use style::values::generics::font::LineHeight;
-use style::values::specified::text::TextDecorationLine as StyloTextDecorationLine;
-
 mod from_styled;
 use from_styled::{
     blend_mode_from, corner_radius_from, dimensions_from, effects_from, fills_from_background,
     flex_container_from, layout_child_from, margin_from, size_from, strokes_from_border,
+    text_align_from, text_effects_from, text_style_from,
 };
 
 /// Parse an HTML string and convert it into a Grida [`SceneGraph`].
@@ -83,14 +78,6 @@ impl SceneBuilder {
             return;
         }
 
-        // Transitional: Stylo reads for the not-yet-rewired paint/text
-        // mappings. Deleted once every emitter consumes `styled`.
-        let data = element.borrow_data();
-        let Some(data) = &data else {
-            return;
-        };
-        let style = data.styles.primary();
-
         let tag = element.local_name_string();
 
         // Decide what IR node type to emit
@@ -126,7 +113,7 @@ impl SceneBuilder {
             // All children are text or inline elements → emit as a single
             // Container (for box model) with an AttributedText child (for text).
             let container_id = self.emit_container(&styled, parent);
-            self.emit_attributed_text(element, style, &styled, Parent::NodeId(container_id));
+            self.emit_attributed_text(element, &styled, Parent::NodeId(container_id));
         } else if has_element_children || has_text_children || is_structural {
             // Mixed content or structural element → Container with separate children.
             let container_id = self.emit_container(&styled, parent);
@@ -139,7 +126,7 @@ impl SceneBuilder {
                 if let DemoNodeData::Text(text) = &child_node.data {
                     let trimmed = text.trim();
                     if !trimmed.is_empty() {
-                        self.emit_text_span(trimmed, style, &styled, container_parent.clone());
+                        self.emit_text_span(trimmed, &styled, container_parent.clone());
                     }
                 }
             }
@@ -266,23 +253,17 @@ impl SceneBuilder {
         }
     }
 
-    fn emit_text_span(
-        &mut self,
-        text: &str,
-        style: &ComputedValues,
-        styled: &StyledElement,
-        parent: Parent,
-    ) {
+    fn emit_text_span(&mut self, text: &str, styled: &StyledElement, parent: Parent) {
         let mut node = self.factory.create_text_span_node();
         node.text = text.to_string();
 
-        let (text_style, fills) = css_text_style_to_cg(style);
+        let (text_style, fills) = text_style_from(styled);
         node.text_style = text_style;
         node.fills = fills;
-        node.text_align = css_text_align_to_cg(style.get_inherited_text().text_align);
-        node.opacity = style.get_effects().opacity;
-        node.effects = css_text_shadow_to_effects(style);
-        node.blend_mode = css_blend_mode_to_cg(style);
+        node.text_align = text_align_from(styled);
+        node.opacity = styled.opacity;
+        node.effects = text_effects_from(styled);
+        node.blend_mode = blend_mode_from(styled);
 
         if styled.flex_grow > 0.0 {
             node.layout_child = Some(LayoutChildStyle {
@@ -303,13 +284,12 @@ impl SceneBuilder {
     fn emit_attributed_text(
         &mut self,
         element: HtmlElement,
-        style: &ComputedValues,
         styled: &StyledElement,
         parent: Parent,
     ) {
         let dom = adapter::dom();
-        let (default_style, default_fills) = css_text_style_to_cg(style);
-        let default_color = Some(abs_color_to_cg(&style.get_inherited_text().color));
+        let (default_style, default_fills) = text_style_from(styled);
+        let default_color = Some(styled.color);
 
         let mut builder = AttributedStringBuilder::new();
         let node_data = dom.node(element.node_id());
@@ -326,12 +306,10 @@ impl SceneBuilder {
                     }
                 }
                 DemoNodeData::Element(_) => {
-                    // Inline element — get its own computed style and collect text.
+                    // Inline element — get its own style record and collect text.
                     let child_el = HtmlElement::from_node_id(*child_id);
-                    let child_data = child_el.borrow_data();
-                    if let Some(child_data) = &child_data {
-                        let child_style = child_data.styles.primary();
-                        Self::collect_inline_text(&mut builder, child_el, child_style);
+                    if let Some(child_styled) = styled_of(child_el) {
+                        Self::collect_inline_text(&mut builder, child_el, &child_styled);
                     }
                 }
                 _ => {} // comments, doctypes, etc. — skip
@@ -353,7 +331,7 @@ impl SceneBuilder {
             layout_child: layout_child_from(styled),
             attributed_string: attr_string,
             default_style,
-            text_align: css_text_align_to_cg(style.get_inherited_text().text_align),
+            text_align: text_align_from(styled),
             text_align_vertical: TextAlignVertical::Top,
             max_lines: None,
             ellipsis: None,
@@ -361,10 +339,10 @@ impl SceneBuilder {
             strokes: Default::default(),
             stroke_width: 0.0,
             stroke_align: StrokeAlign::default(),
-            opacity: style.get_effects().opacity,
-            blend_mode: css_blend_mode_to_cg(style),
+            opacity: styled.opacity,
+            blend_mode: blend_mode_from(styled),
             mask: None,
-            effects: css_text_shadow_to_effects(style),
+            effects: text_effects_from(styled),
         };
 
         self.graph.append_child(Node::AttributedText(node), parent);
@@ -374,11 +352,11 @@ impl SceneBuilder {
     fn collect_inline_text(
         builder: &mut AttributedStringBuilder,
         element: HtmlElement,
-        style: &ComputedValues,
+        styled: &StyledElement,
     ) {
         let dom = adapter::dom();
-        let (run_style, _) = css_text_style_to_cg(style);
-        let run_color = Some(abs_color_to_cg(&style.get_inherited_text().color));
+        let (run_style, _) = text_style_from(styled);
+        let run_color = Some(styled.color);
         let node_data = dom.node(element.node_id());
 
         for child_id in &node_data.children {
@@ -392,10 +370,8 @@ impl SceneBuilder {
                 }
                 DemoNodeData::Element(_) => {
                     let child_el = HtmlElement::from_node_id(*child_id);
-                    let child_data = child_el.borrow_data();
-                    if let Some(child_data) = &child_data {
-                        let child_style = child_data.styles.primary();
-                        Self::collect_inline_text(builder, child_el, child_style);
+                    if let Some(child_styled) = styled_of(child_el) {
+                        Self::collect_inline_text(builder, child_el, &child_styled);
                     }
                 }
                 _ => {}
@@ -446,31 +422,6 @@ impl SceneBuilder {
 // ---------------------------------------------------------------------------
 // CSS → CG type conversion helpers
 // ---------------------------------------------------------------------------
-
-/// Convert a Stylo computed color (GenericColor) to a CG color.
-/// Returns None for fully transparent or currentcolor.
-fn css_color_to_cg(color: &style::values::computed::Color) -> Option<CGColor> {
-    let abs = color.as_absolute()?;
-    let srgb = abs.to_color_space(ColorSpace::Srgb);
-    let r = (srgb.components.0.clamp(0.0, 1.0) * 255.0) as u8;
-    let g = (srgb.components.1.clamp(0.0, 1.0) * 255.0) as u8;
-    let b = (srgb.components.2.clamp(0.0, 1.0) * 255.0) as u8;
-    let a = (srgb.alpha.clamp(0.0, 1.0) * 255.0) as u8;
-    if a == 0 {
-        return None;
-    }
-    Some(CGColor::from_rgba(r, g, b, a))
-}
-
-/// Convert an AbsoluteColor (from the `color` property) to CG.
-fn abs_color_to_cg(color: &AbsoluteColor) -> CGColor {
-    let srgb = color.to_color_space(ColorSpace::Srgb);
-    let r = (srgb.components.0.clamp(0.0, 1.0) * 255.0) as u8;
-    let g = (srgb.components.1.clamp(0.0, 1.0) * 255.0) as u8;
-    let b = (srgb.components.2.clamp(0.0, 1.0) * 255.0) as u8;
-    let a = (srgb.alpha.clamp(0.0, 1.0) * 255.0) as u8;
-    CGColor::from_rgba(r, g, b, a)
-}
 
 /// Parsed CSS margin with per-edge auto tracking.
 struct CSSMargin {
@@ -524,247 +475,6 @@ fn collapse_whitespace(s: &str) -> String {
         }
     }
     result
-}
-
-/// Extract text typography (TextStyleRec) and fill color from CSS computed values.
-/// Shared by emit_text_span and emit_attributed_text.
-fn css_text_style_to_cg(style: &ComputedValues) -> (TextStyleRec, Paints) {
-    let font = style.get_font();
-    let mut text_style = TextStyleRec::from_font("system-ui", 16.0);
-
-    text_style.font_size = font.font_size.computed_size().px();
-    text_style.font_weight = FontWeight(font.font_weight.value() as u32);
-
-    if let Some(first) = font.font_family.families.iter().next() {
-        use style::values::computed::font::SingleFontFamily;
-        text_style.font_family = match first {
-            SingleFontFamily::FamilyName(name) => name.name.to_string(),
-            SingleFontFamily::Generic(generic) => format!("{:?}", generic),
-        };
-    }
-
-    text_style.font_style_italic = font.font_style == style::values::computed::FontStyle::ITALIC;
-
-    match &font.line_height {
-        LineHeight::Normal => {}
-        LineHeight::Number(n) => {
-            text_style.line_height = TextLineHeight::Factor(n.0);
-        }
-        LineHeight::Length(len) => {
-            text_style.line_height = TextLineHeight::Fixed(len.0.px());
-        }
-    }
-
-    let ls = &style.get_inherited_text().letter_spacing;
-    if let Some(len) = ls.0.to_length() {
-        let px = len.px();
-        if px != 0.0 {
-            text_style.letter_spacing = TextLetterSpacing::Fixed(px);
-        }
-    }
-
-    let ws = &style.get_inherited_text().word_spacing;
-    let ws_px = ws.to_length().map(|l| l.px()).unwrap_or(0.0);
-    if ws_px != 0.0 {
-        text_style.word_spacing = TextWordSpacing::Fixed(ws_px);
-    }
-
-    {
-        use style::values::specified::text::TextTransformCase;
-        let tt = style.clone_text_transform();
-        let case = tt.case();
-        text_style.text_transform = if case == TextTransformCase::Uppercase {
-            TextTransform::Uppercase
-        } else if case == TextTransformCase::Lowercase {
-            TextTransform::Lowercase
-        } else if case == TextTransformCase::Capitalize {
-            TextTransform::Capitalize
-        } else {
-            TextTransform::None
-        };
-    }
-
-    let td_line = style.clone_text_decoration_line();
-    if td_line != StyloTextDecorationLine::NONE {
-        let line = if td_line.intersects(StyloTextDecorationLine::LINE_THROUGH) {
-            TextDecorationLine::LineThrough
-        } else if td_line.intersects(StyloTextDecorationLine::UNDERLINE) {
-            TextDecorationLine::Underline
-        } else if td_line.intersects(StyloTextDecorationLine::OVERLINE) {
-            TextDecorationLine::Overline
-        } else {
-            TextDecorationLine::None
-        };
-        if !matches!(line, TextDecorationLine::None) {
-            let td_color = css_color_to_cg(&style.clone_text_decoration_color());
-            let td_style = css_text_decoration_style_to_cg(style);
-            text_style.text_decoration = Some(TextDecorationRec {
-                text_decoration_line: line,
-                text_decoration_color: td_color,
-                text_decoration_style: td_style,
-                text_decoration_skip_ink: None,
-                text_decoration_thickness: None,
-            });
-        }
-    }
-
-    let text_color = &style.get_inherited_text().color;
-    let cg_color = abs_color_to_cg(text_color);
-    let fills = Paints::new([Paint::Solid(SolidPaint {
-        color: cg_color,
-        blend_mode: BlendMode::default(),
-        active: true,
-    })]);
-
-    (text_style, fills)
-}
-
-/// Map CSS text-align to CG TextAlign.
-fn css_text_align_to_cg(align: style::values::computed::TextAlign) -> TextAlign {
-    use style::values::specified::text::TextAlignKeyword;
-    match align {
-        TextAlignKeyword::Start | TextAlignKeyword::Left | TextAlignKeyword::MozLeft => {
-            TextAlign::Left
-        }
-        TextAlignKeyword::End | TextAlignKeyword::Right | TextAlignKeyword::MozRight => {
-            TextAlign::Right
-        }
-        TextAlignKeyword::Center | TextAlignKeyword::MozCenter => TextAlign::Center,
-        TextAlignKeyword::Justify => TextAlign::Justify,
-    }
-}
-
-/// Convert CSS effects (box-shadow, filter, backdrop-filter) to CG LayerEffects.
-fn css_effects_to_cg(style: &ComputedValues) -> LayerEffects {
-    use style::values::generics::effects::Filter;
-
-    let mut shadows = Vec::new();
-    let mut blur = None;
-    let mut backdrop_blur = None;
-
-    // box-shadow → shadows
-    let shadow_list = style.clone_box_shadow();
-    for shadow in shadow_list.0.iter() {
-        let color =
-            css_color_to_cg(&shadow.base.color).unwrap_or_else(|| CGColor::from_rgba(0, 0, 0, 255));
-
-        let fe = FeShadow {
-            dx: shadow.base.horizontal.px(),
-            dy: shadow.base.vertical.px(),
-            blur: shadow.base.blur.px(),
-            spread: shadow.spread.px(),
-            color,
-            active: true,
-        };
-
-        if shadow.inset {
-            shadows.push(FilterShadowEffect::InnerShadow(fe));
-        } else {
-            shadows.push(FilterShadowEffect::DropShadow(fe));
-        }
-    }
-
-    // filter → blur + drop-shadow
-    let filter_list = style.clone_filter();
-    for f in filter_list.0.iter() {
-        match f {
-            Filter::Blur(len) => {
-                blur = Some(FeLayerBlur::from(len.px()));
-            }
-            Filter::DropShadow(s) => {
-                let color =
-                    css_color_to_cg(&s.color).unwrap_or_else(|| CGColor::from_rgba(0, 0, 0, 255));
-                shadows.push(FilterShadowEffect::DropShadow(FeShadow {
-                    dx: s.horizontal.px(),
-                    dy: s.vertical.px(),
-                    blur: s.blur.px(),
-                    spread: 0.0,
-                    color,
-                    active: true,
-                }));
-            }
-            _ => {}
-        }
-    }
-
-    // backdrop-filter → backdrop_blur
-    let bd_list = style.clone_backdrop_filter();
-    for f in bd_list.0.iter() {
-        if let Filter::Blur(len) = f {
-            backdrop_blur = Some(FeBackdropBlur::from(len.px()));
-        }
-    }
-
-    LayerEffects {
-        blur,
-        backdrop_blur,
-        shadows,
-        glass: None,
-        noises: Vec::new(),
-    }
-}
-
-/// Convert CSS text-shadow to CG LayerEffects (for text nodes).
-fn css_text_shadow_to_effects(style: &ComputedValues) -> LayerEffects {
-    let ts_list = style.clone_text_shadow();
-    let mut shadows = Vec::new();
-
-    for s in ts_list.0.iter() {
-        let color = css_color_to_cg(&s.color).unwrap_or_else(|| CGColor::from_rgba(0, 0, 0, 255));
-
-        shadows.push(FilterShadowEffect::DropShadow(FeShadow {
-            dx: s.horizontal.px(),
-            dy: s.vertical.px(),
-            blur: s.blur.px(),
-            spread: 0.0,
-            color,
-            active: true,
-        }));
-    }
-
-    // Text nodes also support filter/backdrop-filter
-    let mut base = css_effects_to_cg(style);
-    base.shadows.extend(shadows);
-    base
-}
-
-/// Convert CSS mix-blend-mode to CG LayerBlendMode.
-fn css_blend_mode_to_cg(style: &ComputedValues) -> LayerBlendMode {
-    use style::computed_values::mix_blend_mode::T as MixBlendMode;
-
-    match style.clone_mix_blend_mode() {
-        MixBlendMode::Normal => LayerBlendMode::PassThrough,
-        MixBlendMode::Multiply => LayerBlendMode::Blend(BlendMode::Multiply),
-        MixBlendMode::Screen => LayerBlendMode::Blend(BlendMode::Screen),
-        MixBlendMode::Overlay => LayerBlendMode::Blend(BlendMode::Overlay),
-        MixBlendMode::Darken => LayerBlendMode::Blend(BlendMode::Darken),
-        MixBlendMode::Lighten => LayerBlendMode::Blend(BlendMode::Lighten),
-        MixBlendMode::ColorDodge => LayerBlendMode::Blend(BlendMode::ColorDodge),
-        MixBlendMode::ColorBurn => LayerBlendMode::Blend(BlendMode::ColorBurn),
-        MixBlendMode::HardLight => LayerBlendMode::Blend(BlendMode::HardLight),
-        MixBlendMode::SoftLight => LayerBlendMode::Blend(BlendMode::SoftLight),
-        MixBlendMode::Difference => LayerBlendMode::Blend(BlendMode::Difference),
-        MixBlendMode::Exclusion => LayerBlendMode::Blend(BlendMode::Exclusion),
-        MixBlendMode::Hue => LayerBlendMode::Blend(BlendMode::Hue),
-        MixBlendMode::Saturation => LayerBlendMode::Blend(BlendMode::Saturation),
-        MixBlendMode::Color => LayerBlendMode::Blend(BlendMode::Color),
-        MixBlendMode::Luminosity => LayerBlendMode::Blend(BlendMode::Luminosity),
-        _ => LayerBlendMode::PassThrough,
-    }
-}
-
-/// Convert CSS text-decoration-style to CG TextDecorationStyle.
-fn css_text_decoration_style_to_cg(style: &ComputedValues) -> Option<TextDecorationStyle> {
-    use style::computed_values::text_decoration_style::T as TDS;
-
-    match style.clone_text_decoration_style() {
-        TDS::Solid => Some(TextDecorationStyle::Solid),
-        TDS::Double => Some(TextDecorationStyle::Double),
-        TDS::Dotted => Some(TextDecorationStyle::Dotted),
-        TDS::Dashed => Some(TextDecorationStyle::Dashed),
-        TDS::Wavy => Some(TextDecorationStyle::Wavy),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/crates/grida/tests/html_import_architecture.rs
+++ b/crates/grida/tests/html_import_architecture.rs
@@ -1,0 +1,85 @@
+//! Architectural tests for the HTML importer seam.
+//!
+//! The importer (`import/html`) consumes the shared htmlcss front-end
+//! and the per-element `StyledElement` record; it must not read Stylo
+//! styles directly. The DOM walk (`csscascade::adapter` / `dom`) stays
+//! on the importer side by design — only *style* resolution is shared.
+//! (The HTML importer seam, gridaco/nothing#30, under the legacy seam
+//! program gridaco/nothing#27.)
+//!
+//! When this test fails, do not loosen the rule. Extend the
+//! `StyledElement` record (renderer-neutrally) and map the new field in
+//! `import/html/from_styled.rs` instead of reaching back into Stylo.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Direct Stylo style reads — owned by `htmlcss/frontend.rs` +
+/// `htmlcss/collect.rs`, never by the importer.
+const FORBIDDEN: &[&str] = &[
+    "use style::",
+    "ComputedValues",
+    "CascadeDriver",
+    "csscascade::cascade",
+];
+
+/// Known follow-ups; keep this list **shrinking, not growing**.
+const ALLOWLIST: &[(&str, &str)] = &[];
+
+fn import_html_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src/import/html")
+}
+
+fn rs_files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for ent in entries.flatten() {
+        let p = ent.path();
+        if p.is_dir() {
+            out.extend(rs_files_under(&p));
+        } else if p.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+    out
+}
+
+fn is_allowlisted(file_rel: &str, forbidden: &str) -> bool {
+    ALLOWLIST
+        .iter()
+        .any(|&(f, n)| file_rel.ends_with(f) && n == forbidden)
+}
+
+#[test]
+fn importer_does_not_read_stylo_styles() {
+    let root = import_html_root();
+    let files = rs_files_under(&root);
+    assert!(!files.is_empty(), "no .rs files under src/import/html?");
+    let mut violations: Vec<String> = Vec::new();
+    for file in files {
+        let content = fs::read_to_string(&file).unwrap_or_default();
+        let rel = file
+            .strip_prefix(&root)
+            .unwrap_or(&file)
+            .to_string_lossy()
+            .to_string();
+        for f in FORBIDDEN {
+            if content.contains(f) && !is_allowlisted(&rel, f) {
+                violations.push(format!("{rel}: references `{f}`"));
+            }
+        }
+    }
+    if !violations.is_empty() {
+        panic!(
+            "HTML importer seam violated:\n  {}\n\n\
+             Style resolution is owned by the shared front-end \
+             (htmlcss/frontend.rs) and the StyledElement record; the \
+             importer maps the record in import/html/from_styled.rs. \
+             See tests/html_import_architecture.rs and \
+             gridaco/nothing#30.",
+            violations.join("\n  ")
+        );
+    }
+}


### PR DESCRIPTION
Re-files #37, which GitHub auto-closed when its stacked base branch (#36's, now merged) was deleted — same commits, now against `main` (merge-tree verified clean). Full description, gates, and the honesty ledger: see #37. Closes #30.