### PR TITLE
test(websem,fixtures): a generated capability-status view, freshness-gated

### DIFF
--- a/crates/websem/tests/capability_status.rs
+++ b/crates/websem/tests/capability_status.rs
@@ -1,0 +1,143 @@
+//! The generated capability-status view and its freshness gate.
+//!
+//! The donor kept a hand-maintained property table and it drifted; this
+//! path's tracker is the code and the corpora (per the D-N decision), and
+//! this gate derives the *scannable* view from them instead of authoring a
+//! second statement. Every refusal line below is the compiler's actual
+//! departure, recompiled here — so `fixtures/web-first/STATUS.md` cannot
+//! drift from behavior without this test failing, the same freshness
+//! discipline the FlatBuffers codegen gate applies to `grida.rs`.
+//!
+//! Regenerate after a rung moves the corpus:
+//!
+//! ```sh
+//! UPDATE_CAPABILITY_STATUS=1 cargo test -p websem --test capability_status
+//! ```
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use websem::{DegradationAction, InitialViewport, SvgFrameSource};
+
+#[derive(Debug, Deserialize)]
+struct PrimitiveSuite {
+    fixtures: Vec<Primitive>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Primitive {
+    id: String,
+    entry: String,
+}
+
+fn corpus_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/web-first")
+}
+
+fn viewport() -> InitialViewport {
+    InitialViewport::new(64.0, 64.0)
+}
+
+#[test]
+fn the_committed_status_view_is_fresh() {
+    let generated = generate();
+    let path = corpus_root().join("STATUS.md");
+    if std::env::var_os("UPDATE_CAPABILITY_STATUS").is_some() {
+        fs::write(&path, &generated).expect("write STATUS.md");
+        return;
+    }
+    let committed = fs::read_to_string(&path).unwrap_or_default();
+    assert_eq!(
+        committed, generated,
+        "fixtures/web-first/STATUS.md is stale — regenerate with \
+         UPDATE_CAPABILITY_STATUS=1 cargo test -p websem --test capability_status"
+    );
+}
+
+fn generate() -> String {
+    let root = corpus_root();
+    let suite: PrimitiveSuite = serde_json::from_str(
+        &fs::read_to_string(root.join("primitives.json")).expect("read primitives.json"),
+    )
+    .expect("parse primitives.json");
+
+    let mut refusals: Vec<String> = fs::read_dir(root.join("unsupported"))
+        .expect("read the unsupported corpus")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".svg"))
+        .map(|name| name.trim_end_matches(".svg").to_string())
+        .collect();
+    refusals.sort();
+
+    let mut out = String::new();
+    out.push_str("# Web-first capability status\n\n");
+    out.push_str(
+        "<!-- GENERATED FILE - do not edit. Regenerate:\n\
+         UPDATE_CAPABILITY_STATUS=1 cargo test -p websem --test capability_status -->\n\n",
+    );
+    out.push_str(
+        "A generated, freshness-gated view of the two corpora that track the\n\
+         SVG engine of record's capability: what renders (the Chromium-baked\n\
+         cells) and what departs by name (the refusal register). Every refusal\n\
+         line is the compiler's actual departure, recompiled by the gate\n\
+         (`crates/websem/tests/capability_status.rs`), so this file cannot\n\
+         drift from behavior. The prose statement of record is\n\
+         [crates/n0_cli/README.md](../../crates/n0_cli/README.md); the rung\n\
+         history is the\n\
+         [D-N register](../../docs/wg/consolidation/svg-engine-of-record.md);\n\
+         the per-fixture rationale is\n\
+         [unsupported/README.md](./unsupported/README.md).\n\n\
+         Not a conformance claim: no score is computed or implied (FLIP is\n\
+         unratified), and the corpus enumerates constructs, not the SVG\n\
+         surface.\n\n",
+    );
+
+    writeln!(out, "## Chromium-baked cells ({})\n", suite.fixtures.len()).unwrap();
+    out.push_str(
+        "Each renders byte-exact against its committed Chromium oracle\n\
+         (six curved cells carry the one declared AA tolerance — see\n\
+         [README.md](./README.md)).\n\n",
+    );
+    for cell in &suite.fixtures {
+        writeln!(out, "- `{}` ({})", cell.id, cell.entry).unwrap();
+    }
+    out.push('\n');
+
+    writeln!(out, "## The refusal register ({})\n", refusals.len()).unwrap();
+    out.push_str(
+        "What the slice refuses, by name, in the compiler's own words —\n\
+         **both refuse** is a document-level contract; **declared** renders\n\
+         the rest and names the hole. A rung that admits a construct moves\n\
+         its row into the cells above.\n\n",
+    );
+    for id in &refusals {
+        let source = fs::read_to_string(root.join("unsupported").join(format!("{id}.svg")))
+            .unwrap_or_else(|error| panic!("{id}: read: {error}"));
+        let strict = SvgFrameSource::from_standalone_svg(source.as_str(), viewport())
+            .err()
+            .unwrap_or_else(|| panic!("{id}: an unsupported fixture must refuse under strict"));
+        match SvgFrameSource::from_standalone_svg_best_effort(source.as_str(), viewport()) {
+            Err(_) => {
+                writeln!(out, "- `{id}` — **both refuse**: {strict}").unwrap();
+            }
+            Ok(best) => {
+                let declared: Vec<String> = best
+                    .degradations()
+                    .iter()
+                    .filter(|d| d.action() != DegradationAction::SamplesAsBase)
+                    .map(|d| format!("{d}"))
+                    .collect();
+                assert!(
+                    !declared.is_empty(),
+                    "{id}: best-effort rendered it with nothing declared — a silent hole"
+                );
+                writeln!(out, "- `{id}` — declared: {}", declared.join("; ")).unwrap();
+            }
+        }
+    }
+
+    out
+}

--- a/fixtures/web-first/README.md
+++ b/fixtures/web-first/README.md
@@ -1,5 +1,10 @@
 # fixtures/web-first
 
+> **Scannable status:** [STATUS.md](./STATUS.md) is the generated,
+> freshness-gated view of both corpora — the baked cells and the refusal
+> register in the compiler's own words
+> (`crates/websem/tests/capability_status.rs` regenerates and gates it).
+
 The Chromium-baked oracle corpus for the SVG engine of record — the path an
 `.svg` or `.html` source takes through one document, one cascade
 (`crates/csscascade`), one compiler (`crates/websem`), one resolved contract

--- a/fixtures/web-first/STATUS.md
+++ b/fixtures/web-first/STATUS.md
@@ -1,0 +1,164 @@
+# Web-first capability status
+
+<!-- GENERATED FILE - do not edit. Regenerate:
+UPDATE_CAPABILITY_STATUS=1 cargo test -p websem --test capability_status -->
+
+A generated, freshness-gated view of the two corpora that track the
+SVG engine of record's capability: what renders (the Chromium-baked
+cells) and what departs by name (the refusal register). Every refusal
+line is the compiler's actual departure, recompiled by the gate
+(`crates/websem/tests/capability_status.rs`), so this file cannot
+drift from behavior. The prose statement of record is
+[crates/n0_cli/README.md](../../crates/n0_cli/README.md); the rung
+history is the
+[D-N register](../../docs/wg/consolidation/svg-engine-of-record.md);
+the per-fixture rationale is
+[unsupported/README.md](./unsupported/README.md).
+
+Not a conformance claim: no score is computed or implied (FLIP is
+unratified), and the corpus enumerates constructs, not the SVG
+surface.
+
+## Chromium-baked cells (85)
+
+Each renders byte-exact against its committed Chromium oracle
+(six curved cells carry the one declared AA tolerance — see
+[README.md](./README.md)).
+
+- `html-inline-svg-currentcolor-rect` (html-inline-svg)
+- `html-webpage-mockup` (html-inline-svg)
+- `svg-currentcolor-rect` (standalone-svg)
+- `svg-fill-named-rect` (standalone-svg)
+- `svg-fill-inherited-rect` (standalone-svg)
+- `svg-fill-invalid-initial-rect` (standalone-svg)
+- `svg-fill-none-rect` (standalone-svg)
+- `svg-style-element-fill-rect` (standalone-svg)
+- `svg-style-attribute-fill-rect` (standalone-svg)
+- `svg-viewbox-uniform-offset-rect` (standalone-svg)
+- `svg-viewbox-unequal-default` (standalone-svg)
+- `svg-preserve-aspect-ratio-explicit` (standalone-svg)
+- `svg-viewbox-only-sizing-rect` (standalone-svg)
+- `svg-sizing-auto-rect` (standalone-svg)
+- `svg-preserve-aspect-ratio-none-stretch` (standalone-svg)
+- `svg-preserve-aspect-ratio-slice-clip` (standalone-svg)
+- `svg-preserve-aspect-ratio-align-max-meet` (standalone-svg)
+- `svg-circle-fill` (standalone-svg)
+- `svg-circle-viewbox-scaled` (standalone-svg)
+- `svg-circle-defaults-clip` (standalone-svg)
+- `svg-circle-zero-r` (standalone-svg)
+- `svg-ellipse-fill` (standalone-svg)
+- `svg-ellipse-auto-rx` (standalone-svg)
+- `svg-ellipse-negative-rx-auto` (standalone-svg)
+- `svg-group-transform-translate` (standalone-svg)
+- `svg-group-nested-transforms` (standalone-svg)
+- `svg-shape-transform-matrix` (standalone-svg)
+- `svg-group-paint-order` (standalone-svg)
+- `svg-group-inherited-fill` (standalone-svg)
+- `svg-non-rendering-elements` (standalone-svg)
+- `svg-group-rotate-quarter` (standalone-svg)
+- `svg-group-rotate-diagonal` (standalone-svg)
+- `svg-path-polygon-fill` (standalone-svg)
+- `svg-path-unclosed-fill` (standalone-svg)
+- `svg-path-relative-commands` (standalone-svg)
+- `svg-path-hv-shorthand` (standalone-svg)
+- `svg-path-cubic-fill` (standalone-svg)
+- `svg-path-smooth-cubic` (standalone-svg)
+- `svg-path-quadratic` (standalone-svg)
+- `svg-path-fill-rule-nonzero` (standalone-svg)
+- `svg-path-fill-rule-evenodd` (standalone-svg)
+- `svg-path-fill-rule-inherited` (standalone-svg)
+- `svg-path-two-subpaths` (standalone-svg)
+- `svg-path-draws-nothing` (standalone-svg)
+- `svg-path-in-scaled-group` (standalone-svg)
+- `svg-path-closed-move-only-contour` (standalone-svg)
+- `svg-stroke-cap-butt` (standalone-svg)
+- `svg-stroke-cap-round` (standalone-svg)
+- `svg-stroke-cap-square` (standalone-svg)
+- `svg-stroke-cap-closed-butt` (standalone-svg)
+- `svg-stroke-cap-closed-round` (standalone-svg)
+- `svg-stroke-cap-closed-square` (standalone-svg)
+- `svg-stroke-cap-circle-round` (standalone-svg)
+- `svg-stroke-cap-circle-square` (standalone-svg)
+- `svg-stroke-cap-ellipse-round` (standalone-svg)
+- `svg-stroke-cap-ellipse-square` (standalone-svg)
+- `svg-stroke-circle` (standalone-svg)
+- `svg-stroke-default-width` (standalone-svg)
+- `svg-stroke-ellipse` (standalone-svg)
+- `svg-stroke-inherited` (standalone-svg)
+- `svg-stroke-invalid-width` (standalone-svg)
+- `svg-stroke-join-bevel` (standalone-svg)
+- `svg-stroke-join-miter` (standalone-svg)
+- `svg-stroke-join-round` (standalone-svg)
+- `svg-stroke-length-units` (standalone-svg)
+- `svg-stroke-line-fill-never-paints` (standalone-svg)
+- `svg-stroke-line` (standalone-svg)
+- `svg-stroke-miter-limit` (standalone-svg)
+- `svg-stroke-nonuniform-scale` (standalone-svg)
+- `svg-stroke-over-fill` (standalone-svg)
+- `svg-stroke-path-closed` (standalone-svg)
+- `svg-stroke-path-open` (standalone-svg)
+- `svg-stroke-rect-centred` (standalone-svg)
+- `svg-stroke-scaled-group` (standalone-svg)
+- `svg-stroke-zero-extent-rect` (standalone-svg)
+- `svg-stroke-zero-length-dot` (standalone-svg)
+- `svg-stroke-zero-width` (standalone-svg)
+- `svg-points-trailing-comma` (standalone-svg)
+- `svg-polygon-fill` (standalone-svg)
+- `svg-polygon-fill-rule-evenodd` (standalone-svg)
+- `svg-polygon-single-point-square-cap` (standalone-svg)
+- `svg-polygon-stroke-closed` (standalone-svg)
+- `svg-polyline-fill-implicit-close` (standalone-svg)
+- `svg-polyline-single-point-square-cap` (standalone-svg)
+- `svg-polyline-stroke-open` (standalone-svg)
+
+## The refusal register (44)
+
+What the slice refuses, by name, in the compiler's own words —
+**both refuse** is a document-level contract; **declared** renders
+the rest and names the hole. A rung that admits a construct moves
+its row into the cells above.
+
+- `svg-anchor` — declared: skipped svg/a[1]: unsupported element <a>
+- `svg-clip-path` — declared: skipped svg/clipPath[1]: unsupported element <clipPath>; skipped svg/rect[2]: unsupported rendering attribute clip-path on <rect> (not yet consumed)
+- `svg-css-transform-property` — declared: skipped svg/rect[2]: unsupported computed style: style attribute on <rect> declares transform, which this cascade does not represent
+- `svg-display-none` — declared: skipped svg/rect[2]: unsupported rendering attribute display on <rect> (not yet consumed)
+- `svg-element-opacity` — declared: skipped svg/rect[2]: unsupported rendering attribute opacity on <rect> (not yet consumed)
+- `svg-fill-opacity` — declared: skipped svg/rect[2]: unsupported rendering attribute fill-opacity on <rect> (not yet consumed)
+- `svg-filter` — declared: skipped svg/filter[1]: unsupported element <filter>; skipped svg/rect[2]: unsupported rendering attribute filter on <rect> (not yet consumed)
+- `svg-foreign-object` — declared: skipped svg/foreignObject[1]: unsupported element <foreignObject>
+- `svg-gradient-paint-server` — declared: skipped svg/linearGradient[1]: unsupported element <linearGradient>; skipped svg/rect[2]: unsupported fill value "url(about:blank#g)"
+- `svg-image` — declared: skipped svg/image[1]: unsupported element <image>
+- `svg-mask` — declared: skipped svg/mask[1]: unsupported element <mask>; skipped svg/rect[2]: unsupported rendering attribute mask on <rect> (not yet consumed)
+- `svg-nested-svg` — declared: skipped svg/svg[1]: unsupported element <svg>
+- `svg-path-arc` — declared: skipped svg/path[1]: path command A on <path> is not yet consumed (an elliptical arc reaches Chromium's rasterizer as conics, which this slice does not emit)
+- `svg-path-css-d-property` — declared: declaration ignored at svg/style[1]: a stylesheet declares d, which this cascade does not represent; elements it matches render without it
+- `svg-path-malformed-d` — declared: skipped svg/path[1]: path data on <path> is invalid at byte 29 (near "qqq")
+- `svg-path-marker-end` — declared: skipped svg/defs[1]: unsupported element <defs>; skipped svg/path[1]: unsupported rendering attribute marker-end on <path> (not yet consumed)
+- `svg-path-no-leading-moveto` — declared: skipped svg/path[1]: path data on <path> is invalid at byte 0 (near "L10 10 L54 54 Z")
+- `svg-path-pathlength` — declared: skipped svg/path[1]: unsupported rendering attribute pathLength on <path> (not yet consumed)
+- `svg-path-trailing-dot-number` — declared: skipped svg/path[1]: path data on <path> is invalid at byte 1 (near "10. 10 L54 10 L54 54 Z")
+- `svg-pattern-paint-server` — declared: skipped svg/pattern[1]: unsupported element <pattern>; skipped svg/rect[2]: unsupported fill value "url(about:blank#p)"
+- `svg-points-odd-coordinate` — declared: skipped svg/polygon[1]: points on <polygon> is invalid at byte 17 (near "")
+- `svg-preserve-aspect-ratio-case-folded` — **both refuse**: preserveAspectRatio "xmidymid meet" is invalid
+- `svg-preserve-aspect-ratio-defer` — **both refuse**: preserveAspectRatio "defer xMidYMid meet" is invalid
+- `svg-preserve-aspect-ratio-invalid-align` — **both refuse**: preserveAspectRatio "xMidYMiddle meet" is invalid
+- `svg-rect-percentage-geometry` — declared: skipped svg/rect[2]: unsupported length width="50%" on <rect>: the percentage basis is not yet consumed
+- `svg-rect-rounded` — declared: skipped svg/rect[2]: unsupported rendering attribute rx on <rect> (not yet consumed)
+- `svg-smil-animate-transform` — declared: skipped svg/g[1]: its authored state is overridden at document load by the unsupported animation at svg/g[1]/animateTransform[1]: animation element <animateTransform> is outside the rect-x proving slice
+- `svg-smil-retarget-href` — **both refuse**: SVG animation at svg/rect[2]/set[1] is unsupported: animation element <set> is outside the rect-x proving slice; it carries href, so its target cannot be attributed to one element without id resolution; it is active at document load, so the authored state it overrides cannot render as the Base view
+- `svg-smil-set-load-active` — declared: skipped svg/rect[2]: its authored state is overridden at document load by the unsupported animation at svg/rect[2]/set[1]: animation element <set> is outside the rect-x proving slice
+- `svg-stroke-dasharray` — declared: skipped svg/path[1]: unsupported rendering attribute stroke-dasharray on <path> (not yet consumed)
+- `svg-stroke-opacity` — declared: skipped svg/rect[1]: unsupported rendering attribute stroke-opacity on <rect> (not yet consumed)
+- `svg-stroke-paint-order` — declared: skipped svg/rect[1]: unsupported rendering attribute paint-order on <rect> (not yet consumed)
+- `svg-stroke-percentage-width` — declared: skipped svg/rect[1]: unsupported stroke value "a percentage stroke-width needs the normalized-diagonal basis"
+- `svg-stroke-sheet-unit-width` — declared: declaration ignored at svg/style[1]: a stylesheet declares a stroke-width in ex, which needs a basis this cascade does not have; elements it matches render at the wrong width
+- `svg-stroke-vector-effect` — declared: skipped svg/g[1]/rect[1]: unsupported rendering attribute vector-effect on <rect> (not yet consumed)
+- `svg-switch` — declared: skipped svg/switch[1]: unsupported element <switch>
+- `svg-text` — declared: skipped svg/text[1]: unsupported element <text>
+- `svg-translucent-fill` — declared: skipped svg/rect[2]: unsupported fill value "translucent paint (alpha 0.5) is not yet gated against Chromium"
+- `svg-use` — declared: skipped svg/use[1]: unsupported element <use>; skipped svg/defs[1]: unsupported element <defs>
+- `svg-viewbox-invalid-token` — **both refuse**: viewBox "0 0 invalid 64 64" is invalid
+- `svg-viewbox-repeated-comma` — **both refuse**: viewBox "0 0,,64 64" is invalid
+- `svg-viewbox-trailing-comma` — **both refuse**: viewBox "0 0 64 64," is invalid
+- `svg-visibility-hidden` — declared: skipped svg/rect[2]: unsupported rendering attribute visibility on <rect> (not yet consumed)
+- `svg-width-percentage` — **both refuse**: unsupported SVG viewport sizing: percentage width="50%" on the root <svg> is not yet consumed

--- a/fixtures/web-first/unsupported/README.md
+++ b/fixtures/web-first/unsupported/README.md
@@ -14,6 +14,10 @@ structural path. What that gate defends is the invariant, stated over a whole
 directory — *nothing here renders silently*. Individual constructs are pinned a
 second time, from inline sources, by the contract law that owns each rung.
 
+The scannable, generated view of this register (beside the baked cells) is
+[../STATUS.md](../STATUS.md), freshness-gated by
+`crates/websem/tests/capability_status.rs`.
+
 | File | Required result |
 | --- | --- |
 | `svg-viewbox-invalid-token.svg` | Reject the malformed `viewBox`; do not discard the bad token. |


### PR DESCRIPTION
The donor tracks CSS properties in a hand-maintained ✅/⚠️/❌ table ([docs/wg/feat-2d/htmlcss.md](https://github.com/gridaco/nothing/blob/main/docs/wg/feat-2d/htmlcss.md)) — useful, but nothing gates it, and it drifted. D-N chose the opposite for the n0 path: the code and the corpora are the tracker. That cannot drift, but it cannot be scanned either.

[`fixtures/web-first/STATUS.md`](https://github.com/gridaco/nothing/blob/chore/capability-status/fixtures/web-first/STATUS.md) is the middle: a **generated** view of both corpora — the 85 Chromium-baked cells and the 44-row refusal register, each refusal line being the compiler's actual departure, *recompiled* by the gate (`crates/websem/tests/capability_status.rs`). The gate holds the committed file byte-for-byte against regeneration — the same freshness discipline the FlatBuffers codegen gate applies to `grida.rs` — so a rung that moves the corpus without regenerating the view fails CI.

Not a second statement of record: the prose statement stays `crates/n0_cli/README.md` (linked from the header), no score is computed or implied, and `fixtures/` is oxfmt-ignored so the generator owns the formatting.

Regenerate: `UPDATE_CAPABILITY_STATUS=1 cargo test -p websem --test capability_status`