### PR TITLE
build(emsdk): upgrade the pinned SDK 5.0.0 → 6.0.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,19 +63,9 @@ a comment.
 
 ## Setup
 
-```sh
-# 1. emsdk submodule (needed for WASM builds only). `bin/activate-emsdk` pins
-#    the SDK version and needs python >= 3.10 — macOS ships 3.9, so a WASM
-#    build there wants `brew install python` first.
-git submodule update --init
-
-# 2. Rust toolchain auto-pins via rust-toolchain.toml (rustfmt + clippy included)
-cargo --version
-
-# 3. ninja is required for skia-bindings
-brew install ninja            # macOS
-# sudo apt-get install -y ninja-build   # Ubuntu/Debian
-```
+[`docs/contributing/setup.md`](./docs/contributing/setup.md) is the statement of
+record — Rust toolchain and `ninja` for the base, the pinned emsdk for a WASM
+build. Do not restate it here.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ a comment.
 ## Setup
 
 ```sh
-# 1. emsdk submodule (needed for WASM builds only)
+# 1. emsdk submodule (needed for WASM builds only). `bin/activate-emsdk` pins
+#    the SDK version and needs python >= 3.10 — macOS ships 3.9, so a WASM
+#    build there wants `brew install python` first.
 git submodule update --init
 
 # 2. Rust toolchain auto-pins via rust-toolchain.toml (rustfmt + clippy included)

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ yet: any layout engine, any editor host, any WebAssembly target.
 
 **Nothing here is published.** There are no releases, and the only shipped
 artifact in the tree is the frozen v1 wasm package. Run it from a clone —
-[setup](./AGENTS.md#setup).
+[setup](./docs/contributing/setup.md).
 
 ## One pipeline
 

--- a/bin/activate-emsdk
+++ b/bin/activate-emsdk
@@ -14,9 +14,9 @@ EMSDK_ROOT = os.path.join('third_party', 'externals', 'emsdk')
 
 EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
 
-# Keep this aligned with local and CI builds. The emsdk submodule carries a
-# few installer fixes beyond its 5.0.0 tag; the installed SDK stays at 5.0.0.
-EMSDK_VERSION = '5.0.0'
+# Keep this aligned with local and CI builds. The submodule is pinned to the
+# emsdk tag of the same name, so the installer and the SDK it installs agree.
+EMSDK_VERSION = '6.0.5'
 
 def main():
     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:

--- a/crates/grida-canvas-wasm/AGENTS.md
+++ b/crates/grida-canvas-wasm/AGENTS.md
@@ -206,54 +206,8 @@ For production deployment:
 4. **Consistent Output**: Standardized success messages and error handling
 5. **Extensibility**: Easy to add new build configurations or commands
 
-## Troubleshooting / Building WASM locally (vanilla way)
+## Building WASM locally (vanilla way)
 
-> follow this if you can't use justfile or os-specific trouble shooting.
-
-The WASM build targets `wasm32-unknown-emscripten` and requires the Emscripten SDK.
-The steps below were tested on a fresh Ubuntu container and produced
-`lib/bin/grida_canvas_wasm.wasm` and `lib/bin/grida-canvas-wasm.js`.
-
-1. **Fetch submodules and install build tools**
-
-   ```bash
-   git submodule update --init --recursive
-   rustup target add wasm32-unknown-emscripten
-   pnpm install
-   ```
-
-2. **Install and activate Emscripten**
-
-   Use the activator rather than `emsdk install latest` — it holds the pinned
-   SDK version, and an unpinned `latest` drifts away from what CI builds. It
-   needs python >= 3.10.
-
-   ```bash
-   python3 bin/activate-emsdk   # from the repo root
-   ```
-
-3. **(Ubuntu only) provide missing locale headers**
-   Some Ubuntu images lack `xlocale.h` which breaks the Skia build. A simple symbolic link fixes it:
-
-   ```bash
-   sudo ln -s /usr/include/locale.h /usr/include/xlocale.h
-   ```
-
-4. **Build the crate**
-
-   ```bash
-   cd crates/grida-canvas-wasm
-   source ../../third_party/externals/emsdk/emsdk_env.sh
-   export CC=emcc CXX=em++ AR=emar
-   cargo build --release --target wasm32-unknown-emscripten
-   ```
-
-5. **Copy artifacts and package**
-   ```bash
-   mkdir -p lib/bin
-   cp ../../target/wasm32-unknown-emscripten/release/*.js lib/bin/
-   cp ../../target/wasm32-unknown-emscripten/release/*.wasm lib/bin/
-   pnpm --filter @grida/canvas-wasm build
-   ```
-
-After these steps the compiled module is ready in `lib/bin/` for consumption or publishing.
+Toolchain prerequisites and the step-by-step build without the justfile live in
+[`docs/contributing/setup.md`](../../docs/contributing/setup.md). Do not restate
+them here.

--- a/crates/grida-canvas-wasm/AGENTS.md
+++ b/crates/grida-canvas-wasm/AGENTS.md
@@ -224,11 +224,12 @@ The steps below were tested on a fresh Ubuntu container and produced
 
 2. **Install and activate Emscripten**
 
+   Use the activator rather than `emsdk install latest` — it holds the pinned
+   SDK version, and an unpinned `latest` drifts away from what CI builds. It
+   needs python >= 3.10.
+
    ```bash
-   cd third_party/externals/emsdk
-   ./emsdk install latest
-   ./emsdk activate latest
-   cd -
+   python3 bin/activate-emsdk   # from the repo root
    ```
 
 3. **(Ubuntu only) provide missing locale headers**

--- a/crates/grida-canvas-wasm/justfile
+++ b/crates/grida-canvas-wasm/justfile
@@ -12,10 +12,12 @@ _wasm32_unknown_emscripten_env := "rustup target add wasm32-unknown-emscripten; 
 # every emscripten target, because Skia's wasm GN toolchain emits that suffix
 # since milestone 148. The published prebuilt archives ship those libraries
 # already named `lib<x>.a`, so the copy panics on a missing source before a
-# single line is compiled. The library list comes from the enabled features,
-# not from whether ninja ran, so this only bites feature sets pulling in
-# textlayout or svg — which is exactly this crate's. Present in every
-# skia-bindings from 0.97.0 through 0.99.0; no version choice avoids it.
+# single line is compiled. The enabled features extend that library list but
+# `skia` itself is always on it, so every published emscripten prebuilt is
+# affected, whatever the feature set. Present in every skia-bindings from
+# 0.97.0 through 0.99.0; no version choice avoids it. Reported upstream as
+# <https://github.com/rust-skia/rust-skia/issues/1310>; removing this shim is
+# gridaco/nothing#66.
 #
 # Seeding the expected names is an identity operation: the build script copies
 # each seeded file straight back onto the file it was copied from, so nothing

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -1,0 +1,127 @@
+# Contributing to nothing | Setup
+
+What a fresh clone needs before the workspace builds. Everything here is
+per-machine — none of it is checked in.
+
+## Base
+
+```sh
+# 1. Rust toolchain — auto-pins via rust-toolchain.toml (rustfmt + clippy included)
+cargo --version
+
+# 2. ninja — required by skia-bindings
+brew install ninja                      # macOS
+# sudo apt-get install -y ninja-build   # Ubuntu/Debian
+```
+
+That covers `cargo test` and the `n0` binary. `skia-bindings` downloads a
+prebuilt Skia for target/feature combinations that rust-skia publishes and
+builds from source otherwise, which is what ninja is for — so the first
+build on a combination without a prebuilt is long, and later ones are not.
+
+## WebAssembly
+
+Only needed to build `@grida/canvas-wasm`. Nothing else in the workspace
+targets WASM — see the caveats in [AGENTS.md](../../AGENTS.md#current-state-and-caveats).
+
+### Emscripten
+
+The SDK is a submodule, installed at a pinned version by `bin/activate-emsdk`:
+
+```sh
+git submodule update --init third_party/externals/emsdk
+python3 bin/activate-emsdk
+```
+
+Two things to know:
+
+- **`bin/activate-emsdk` is the source of truth for the SDK version.** Do not
+  run `emsdk install latest` instead — an unpinned SDK drifts away from the one
+  CI builds with, and Emscripten is not ABI-stable across major versions.
+- **The activator needs python >= 3.10**, an emsdk 6.0.4+ requirement. macOS
+  ships 3.9, so `brew install python` first; Linux CI images are already past
+  that floor.
+
+### Build
+
+The crate's [justfile](../../crates/grida-canvas-wasm/justfile) is the supported
+path — it activates emsdk, builds, copies the artifacts into `lib/bin/`, and
+packages:
+
+```sh
+brew install just               # or: cargo install just
+cd crates/grida-canvas-wasm && just build
+```
+
+`just dev` is the same thing in debug mode (~100MB output rather than ~10MB).
+Publishing is separate — see
+[PUBLISHING.md](../../crates/grida-canvas-wasm/PUBLISHING.md).
+
+### Building without the justfile
+
+Follow this if `just` is unavailable, or when isolating an OS-specific failure.
+These steps were tested on a fresh Ubuntu container and produce the same
+`lib/bin/grida_canvas_wasm.wasm` and `lib/bin/grida-canvas-wasm.js`.
+
+1. **Fetch submodules and install build tools**
+
+   ```sh
+   git submodule update --init --recursive
+   rustup target add wasm32-unknown-emscripten
+   pnpm install
+   ```
+
+2. **Install and activate Emscripten** — as above, from the repo root:
+
+   ```sh
+   python3 bin/activate-emsdk
+   ```
+
+3. **(Ubuntu only) provide missing locale headers.** Some Ubuntu images lack
+   `xlocale.h`, which breaks the Skia build. A symlink fixes it:
+
+   ```sh
+   sudo ln -s /usr/include/locale.h /usr/include/xlocale.h
+   ```
+
+4. **Build the crate**
+
+   ```sh
+   cd crates/grida-canvas-wasm
+   source ../../third_party/externals/emsdk/emsdk_env.sh
+   export CC=emcc CXX=em++ AR=emar
+   cargo build --release --target wasm32-unknown-emscripten
+   ```
+
+   If this fails inside the `skia-bindings` build script with
+   `failed to prepare emscripten archive for linking: … lib<x>.wasm.a … No such
+   file or directory`, you have hit a known defect in the published prebuilts
+   (<https://github.com/rust-skia/rust-skia/issues/1310>). Seed the expected
+   names and re-run the build — this is what the justfile does automatically:
+
+   ```sh
+   for f in ../../target/wasm32-unknown-emscripten/*/build/skia-bindings-*/out/skia/lib*.a; do
+     [ -e "${f%.a}.wasm.a" ] || cp "$f" "${f%.a}.wasm.a"
+   done
+   ```
+
+5. **Copy artifacts and package**
+
+   ```sh
+   mkdir -p lib/bin
+   cp ../../target/wasm32-unknown-emscripten/release/*.js lib/bin/
+   cp ../../target/wasm32-unknown-emscripten/release/*.wasm lib/bin/
+   pnpm --filter @grida/canvas-wasm build
+   ```
+
+After these steps the compiled module is in `lib/bin/`, ready for consumption
+or publishing.
+
+## See also
+
+- [`crates/grida-canvas-wasm/AGENTS.md`](../../crates/grida-canvas-wasm/AGENTS.md)
+  — build system internals, bundler compatibility, output layout.
+- [`crates/grida-canvas-wasm/PUBLISHING.md`](../../crates/grida-canvas-wasm/PUBLISHING.md)
+  — cutting an npm release.
+- [Web Platform Tests](./wpt.md) — the separate sibling-checkout setup that
+  suite needs.


### PR DESCRIPTION
Moves the pinned Emscripten SDK from 5.0.0 to 6.0.5.

The submodule advances to the `6.0.5` tag — a clean fast-forward, so the
three installer fixes the old pin carried beyond its `5.0.0` tag are all
contained in it — and `bin/activate-emsdk` installs the matching version.
Before this, the installer sat three commits past 5.0.0 while installing
5.0.0; now the two agree.

## Verification

A cold `wasm32-unknown-emscripten` release build (target dir removed, so
skia-bindings re-downloaded its prebuilt archive and every crate
recompiled):

- The prebuilt Skia archives published by rust-skia link cleanly under
  emcc 6.0.5 — no warnings, 3m09s.
- The module instantiates in node with `_init`, `HEAPU8`, `UTF8ToString`,
  `stringToUTF8`, and `GL` all present — the same properties
  `lib/__test__/environment-node-smoke.test.ts` asserts.
- Output is 17,952,077 bytes, against 17,960,783 on 5.0.0.

The checked-in `lib/bin/` artifacts are untouched; they remain the frozen
v1 release binary.

## Consequences worth stating

**emsdk 6.0.4+ requires python >= 3.10**
([emscripten-core/emsdk#1743](https://github.com/emscripten-core/emsdk/pull/1743)).
A Mac whose `python3` is the stock 3.9 now fails the activator with a
clear error from emsdk itself. Recorded in the setup steps; CI runners
are already past that floor.

**The 5.0.0 SDK shipped a stale sysroot cache** whose generated
`version.h` declared `__EMSCRIPTEN_major__ 4` / tiny `24` while
`emscripten-version.txt` said 5.0.0. 6.0.5 reports its own version
correctly.

**This does not unblock a from-source Skia wasm build.** That is blocked
on Skia's `GrGLFunctions.h` testing `__EMSCRIPTEN_major__` without
including `<emscripten/version.h>` — the macro is not a compiler builtin,
so it reads 0, and the pre-5 four-argument `ClientWaitSync` typedef gets
selected against a three-argument emscripten symbol. 6.0.5 behaves
identically, and additionally deprecates the lowercase macro spelling
Skia uses. Nothing in this repo depends on that path today; the wasm
build consumes prebuilts.

**It does not affect the missing-`.wasm.a` prebuilt defect**
([rust-skia/rust-skia#1310](https://github.com/rust-skia/rust-skia/issues/1310)).
The retry shim in the justfile fired on this build exactly as before and
is still required; removal is tracked in gridaco/nothing#66.

## Also in this PR

A separate commit corrects that shim's comment. It claimed the panic only
bites feature sets pulling in `textlayout` or `svg`; in fact
`from_features` pushes `lib::SKIA` onto `ninja_built_libraries`
unconditionally, so every published emscripten prebuilt trips it. The
comment now also carries the upstream and removal links, which it
predated.