### PR TITLE
text-1a: the textlayout resolver at oracle v0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ build. Do not restate it here.
 ```sh
 # check (each crate must pass independently)
 cargo check -p htmlcss -p grida -p grida-canvas-wasm -p grida_dev -p n0 -p n0-model \
-  -p websem -p rframe -p animation-sampling -p n0_cli
+  -p websem -p rframe -p animation-sampling -p textlayout -p n0_cli
 
 # tests
 cargo test -p grida     # legacy engine tests
@@ -109,6 +109,7 @@ python3 bin/activate-flatc -- --rust -o crates/grida/src/io/generated format/gri
 | `crates/websem`             | the Web semantic compiler: an SVG or HTML source → one namespace-aware document → one Stylo cascade → `rframe::Frame`. Owns no parser and no painter; decides what the engine will and will not render |
 | `crates/rframe`             | the resolved render contract (`Frame`): the visual facts a producer states after resolving its source. Contract-only and backend-free — no document, no cascade, no paint call |
 | `crates/animation-sampling` | the time axis: Base or one exact signed-nanosecond Sample, with no ambient clock                        |
+| `crates/textlayout`         | the Web family's text resolution oracle ([the text-layout RFD](./docs/wg/feat-paragraph/text-layout.md) at its v0 profile): attributed text + a declared font environment → one immutable resolved layout, or a typed refusal. Owns no font discovery, no render contract, no clock — and is deliberately *not* an engine-wide text service while the D-M shaped-text stage stays open |
 | `crates/n0_cli`             | thin `n0` file-render command on the SVG engine of record (`websem → rframe → n0`): Base and exact-time SVG/HTML renders at WxH-as-initial-viewport — best-effort by default (constructs outside the admitted slice declared on stderr), `--strict` refuses loudly. Its README is the statement of record for that slice |
 | `archive/model-v2/`                 | the frozen v2 workbench archive (phase papers, experiment verdicts, demo pages); paths inside the frozen papers refer to the pre-promotion layout — see its README's map |
 | `format/`                   | the FlatBuffers schema (`grida.fbs`) — **source of truth**; see `format/AGENTS.md`         |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5584,6 +5584,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "textlayout"
+version = "0.0.0"
+dependencies = [
+ "rustybuzz",
+]
+
+[[package]]
 name = "thin-vec"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/n0_cli",
   "crates/n0_dev",
   "crates/rframe",
+  "crates/textlayout",
   "crates/websem",
 ]
 

--- a/crates/textlayout/Cargo.toml
+++ b/crates/textlayout/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "textlayout"
+version = "0.0.0"
+edition = "2024"
+description = "PROVISIONAL, INTERNAL, BREAKABLE. The Web family's text resolution oracle: attributed text + a declared font environment -> one immutable resolved text layout, or a typed refusal. Implements the minimal profile of docs/wg/feat-paragraph/text-layout.md at oracle v0."
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+# The one shaping dependency, pinned exactly: ORACLE_VERSION's stability
+# claim is mechanical only if the shaper cannot drift under it. ttf-parser is
+# consumed through rustybuzz's re-export so exactly one face type exists;
+# the coordinate is the one the workspace lock already carries via vendored
+# usvg, and the oracle version was measured against it.
+rustybuzz = "=0.20.1"
+
+[lints]
+workspace = true

--- a/crates/textlayout/src/artifact.rs
+++ b/crates/textlayout/src/artifact.rs
@@ -1,0 +1,269 @@
+//! The immutable resolved text layout — the one answer every
+//! geometry-sensitive consumer projects from.
+//!
+//! Geometry is stated in the text node's **local logical space**: x grows
+//! right, y grows down, the pen origin is `(0, 0)` on the alphabetic
+//! baseline, and fractional values are preserved (device-pixel rounding is
+//! not part of text resolution). Font units are y-up; the flip happens
+//! exactly once, inside this crate, so no consumer ever re-derives it.
+
+use std::sync::Arc;
+
+use crate::ORACLE_VERSION;
+use crate::environment::FontKey;
+
+/// An axis-aligned box in the artifact's local space. Deliberately this
+/// crate's own four floats: the artifact depends on no geometry vocabulary,
+/// so no render contract leaks in through a shared rectangle type.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BoundsBox {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+/// The face one resolution actually used, by verified identity — glyph ids
+/// in this artifact are meaningful only together with this face.
+#[derive(Clone, Debug)]
+pub struct ResolvedFace {
+    pub key: FontKey,
+    pub face_index: u32,
+    pub units_per_em: u16,
+}
+
+/// Line metrics in local px: distances from the baseline, both positive
+/// (ascent reaches up, descent reaches down).
+///
+/// Oracle v0's metric policy is the face's `hhea` ascent/descent as the
+/// parser reports them; line gap (leading) is a declared deferral, arriving
+/// as a field when a consumer first needs line stacking. For the pinned gate
+/// font every metric table agrees, which is why the gate can hold before the
+/// policy question is forced.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LineMetrics {
+    pub ascent: f32,
+    pub descent: f32,
+}
+
+/// One positioned glyph: identity, placement, and its mapping back to the
+/// source bytes that produced it.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlacedGlyph {
+    /// Glyph identifier in the resolved face's space.
+    pub glyph_id: u16,
+    /// Pen x of this glyph's origin, in local px from the run origin.
+    pub x: f32,
+    /// This glyph's advance, in local px. The next pen position is
+    /// `x + advance`; fractional advances are preserved.
+    pub advance: f32,
+    /// UTF-8 byte offset into the source text of the cluster this glyph
+    /// renders — shaping's mapping, not a per-`char` guess.
+    pub cluster: u32,
+}
+
+/// Receives one glyph's outline in the artifact's local y-down px space,
+/// positioned at the glyph's pen origin on the baseline. The vocabulary
+/// mirrors what shaping can produce (TrueType quadratics, CFF cubics);
+/// consumers translate into their own path types.
+pub trait OutlineSink {
+    fn move_to(&mut self, x: f32, y: f32);
+    fn line_to(&mut self, x: f32, y: f32);
+    fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32);
+    fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32);
+    fn close(&mut self);
+}
+
+/// The immutable resolved text layout at oracle v0: one style run of
+/// horizontal left-to-right text, already shaped, measured, and mapped.
+///
+/// Consumers project, they do not re-resolve: painting realizes the recorded
+/// glyphs, measurement reads the recorded bounds, and any layout-affecting
+/// input change means a *new* resolution — this value never mutates.
+#[derive(Clone)]
+pub struct ResolvedTextLayout {
+    oracle_version: &'static str,
+    source: String,
+    face: ResolvedFace,
+    font_size: f32,
+    metrics: LineMetrics,
+    glyphs: Vec<PlacedGlyph>,
+    advance: f32,
+    ink_bounds: Option<BoundsBox>,
+    /// The exact bytes of the resolved face, retained so outline queries
+    /// answer from the same identity that shaped — never from a second load.
+    font_bytes: Arc<[u8]>,
+}
+
+impl ResolvedTextLayout {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        source: String,
+        face: ResolvedFace,
+        font_size: f32,
+        metrics: LineMetrics,
+        glyphs: Vec<PlacedGlyph>,
+        advance: f32,
+        ink_bounds: Option<BoundsBox>,
+        font_bytes: Arc<[u8]>,
+    ) -> Self {
+        Self {
+            oracle_version: ORACLE_VERSION,
+            source,
+            face,
+            font_size,
+            metrics,
+            glyphs,
+            advance,
+            ink_bounds,
+            font_bytes,
+        }
+    }
+
+    /// The oracle version that produced this artifact.
+    pub fn oracle_version(&self) -> &'static str {
+        self.oracle_version
+    }
+
+    /// The exact source text this resolution shaped.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub fn face(&self) -> &ResolvedFace {
+        &self.face
+    }
+
+    pub fn font_size(&self) -> f32 {
+        self.font_size
+    }
+
+    pub fn metrics(&self) -> LineMetrics {
+        self.metrics
+    }
+
+    /// The placed glyphs in visual order — which at oracle v0 is also
+    /// logical order, a fact of the LTR single-run profile rather than an
+    /// assumption a consumer may carry to later versions.
+    pub fn glyphs(&self) -> &[PlacedGlyph] {
+        &self.glyphs
+    }
+
+    /// The run's total advance in local px. An anchor policy (SVG
+    /// `text-anchor`) is a *projection* of this recorded measurement by the
+    /// document layer that owns the anchor point — not a re-measurement.
+    pub fn advance(&self) -> f32 {
+        self.advance
+    }
+
+    /// Typographic extents: the advance run crossed with ascent/descent.
+    /// Present even where no ink is (an all-spaces run has logical extent).
+    pub fn logical_bounds(&self) -> BoundsBox {
+        BoundsBox {
+            x: 0.0,
+            y: -self.metrics.ascent,
+            width: self.advance,
+            height: self.metrics.ascent + self.metrics.descent,
+        }
+    }
+
+    /// The tight union of glyph outline extents, before any paint effect.
+    /// `None` when the run draws nothing (spaces advance without ink).
+    pub fn ink_bounds(&self) -> Option<BoundsBox> {
+        self.ink_bounds
+    }
+
+    /// Stream the outline of the glyph at `index` in [`Self::glyphs`] into
+    /// `sink`, positioned at its recorded pen origin, in local y-down px.
+    /// Returns `false` for a glyph with no outline (the space): it
+    /// contributes advance, not geometry, and a consumer emits nothing.
+    ///
+    /// Index-based on purpose: glyph identifiers are meaningful only with
+    /// this artifact's face, so only placements this resolution recorded can
+    /// be realized — a glyph from another layout has no route in.
+    ///
+    /// # Panics
+    ///
+    /// If `index` is out of range, like any slice index.
+    ///
+    /// Answers from the retained resolved bytes — re-parsing the face per
+    /// query is deliberate v0 policy: the reuse structure exists (the bytes
+    /// and identity are pinned here), and a memo arrives only measured,
+    /// with its `*_matches_fresh` law.
+    pub fn outline(&self, index: usize, sink: &mut dyn OutlineSink) -> bool {
+        let glyph = &self.glyphs[index];
+        let Ok(face) = rustybuzz::ttf_parser::Face::parse(&self.font_bytes, self.face.face_index)
+        else {
+            // The face parsed at resolution; bytes are immutable since.
+            unreachable!("resolved font bytes stopped parsing");
+        };
+        let scale = self.font_size / f32::from(self.face.units_per_em);
+        let mut flip = FlipSink {
+            sink,
+            pen_x: glyph.x,
+            scale,
+        };
+        face.outline_glyph(rustybuzz::ttf_parser::GlyphId(glyph.glyph_id), &mut flip)
+            .is_some()
+    }
+}
+
+impl std::fmt::Debug for ResolvedTextLayout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The retained font bytes are identity, not information — the key
+        // already names them, so diagnostics never dump a font.
+        f.debug_struct("ResolvedTextLayout")
+            .field("oracle_version", &self.oracle_version)
+            .field("source", &self.source)
+            .field("face", &self.face)
+            .field("font_size", &self.font_size)
+            .field("metrics", &self.metrics)
+            .field("glyphs", &self.glyphs)
+            .field("advance", &self.advance)
+            .field("ink_bounds", &self.ink_bounds)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Maps y-up font units onto the artifact's y-down local px space:
+/// `x' = pen + x·s`, `y' = −y·s`. The one home of the flip.
+struct FlipSink<'a> {
+    sink: &'a mut dyn OutlineSink,
+    pen_x: f32,
+    scale: f32,
+}
+
+impl FlipSink<'_> {
+    fn map(&self, x: f32, y: f32) -> (f32, f32) {
+        (self.pen_x + x * self.scale, -y * self.scale)
+    }
+}
+
+impl rustybuzz::ttf_parser::OutlineBuilder for FlipSink<'_> {
+    fn move_to(&mut self, x: f32, y: f32) {
+        let (x, y) = self.map(x, y);
+        self.sink.move_to(x, y);
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        let (x, y) = self.map(x, y);
+        self.sink.line_to(x, y);
+    }
+
+    fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32) {
+        let (x1, y1) = self.map(x1, y1);
+        let (x, y) = self.map(x, y);
+        self.sink.quad_to(x1, y1, x, y);
+    }
+
+    fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32) {
+        let (x1, y1) = self.map(x1, y1);
+        let (x2, y2) = self.map(x2, y2);
+        let (x, y) = self.map(x, y);
+        self.sink.curve_to(x1, y1, x2, y2, x, y);
+    }
+
+    fn close(&mut self) {
+        self.sink.close();
+    }
+}

--- a/crates/textlayout/src/environment.rs
+++ b/crates/textlayout/src/environment.rs
@@ -1,0 +1,85 @@
+//! The resolution environment: a manifest of exact font bytes, never an
+//! ambient promise.
+//!
+//! A family name, file path, or OS handle is not a font identity — the same
+//! name may resolve to different bytes. Identity here is a caller-supplied
+//! content digest: the *host* (n0_cli, a test, a bake) verifies the bytes it
+//! loads against the digest it was given and refuses before constructing an
+//! environment, so a [`FontKey`] inside this crate is already-verified
+//! identity, propagated opaquely into every artifact. There is no silent
+//! system fallback because there is no system: an empty environment resolves
+//! no text at all.
+
+use std::sync::Arc;
+
+/// Declared content identity of one font resource: the SHA-256 digest of its
+/// exact bytes, as stated by the host that loaded them. Opaque to this crate
+/// and carried into every resolved artifact.
+///
+/// The declaration is the host's responsibility and the host's law: the
+/// text-oracle brief requires a hash-bearing surface verified before any
+/// pixel, and that verification gate lands with the first host. In-crate
+/// hashing is deliberately absent — it would grow the dependency perimeter,
+/// which is a decision, not a convenience — so this type never claims a
+/// verification it did not perform.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FontKey([u8; 32]);
+
+impl FontKey {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(digest)
+    }
+
+    pub const fn digest(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for FontKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The short prefix is enough to name the identity in diagnostics.
+        write!(
+            f,
+            "FontKey({:02x}{:02x}{:02x}{:02x}…)",
+            self.0[0], self.0[1], self.0[2], self.0[3]
+        )
+    }
+}
+
+/// One declared font: verified identity, the exact bytes, the face index for
+/// collections, and the family name the environment answers to.
+///
+/// The declared family is part of the manifest, not metadata read from the
+/// font — the environment answers exactly the names its host declared, so a
+/// renamed file cannot silently satisfy a different family.
+#[derive(Clone, Debug)]
+pub struct FontResource {
+    pub key: FontKey,
+    pub family: String,
+    pub face_index: u32,
+    pub bytes: Arc<[u8]>,
+}
+
+/// The complete set of fonts a resolution may use. Empty by default: text
+/// resolved against an empty environment is a typed refusal, never tofu.
+#[derive(Clone, Debug, Default)]
+pub struct Environment {
+    fonts: Vec<FontResource>,
+}
+
+impl Environment {
+    pub fn new(fonts: Vec<FontResource>) -> Self {
+        Self { fonts }
+    }
+
+    /// Exact, case-sensitive family match — oracle v0 has no fallback list,
+    /// no aliasing, and no synthesis. First declaration wins so a manifest
+    /// is order-deterministic.
+    pub(crate) fn find(&self, family: &str) -> Option<&FontResource> {
+        self.fonts.iter().find(|font| font.family == family)
+    }
+
+    pub fn fonts(&self) -> &[FontResource] {
+        &self.fonts
+    }
+}

--- a/crates/textlayout/src/lib.rs
+++ b/crates/textlayout/src/lib.rs
@@ -1,0 +1,60 @@
+//! `textlayout` — PROVISIONAL · INTERNAL · BREAKABLE.
+//!
+//! The Web family's **text resolution oracle** — the producer-side
+//! implementation of the single text-resolution contract
+//! ([`docs/wg/feat-paragraph/text-layout.md`]), at its smallest honest
+//! profile:
+//!
+//! ```text
+//! attributed text + explicit font environment
+//!     -> resolved text layout | typed resolution failure     (oracle v0)
+//! ```
+//!
+//! **Oracle v0 resolves one style run of printable-ASCII, horizontal,
+//! left-to-right text with no wrapping, no fallback, and no synthesis.**
+//! The repertoire is an explicit admit-list enforced by the resolver
+//! itself — never an accident of a font's coverage — and everything outside
+//! the profile is a typed refusal, not an approximation. Coverage grows by
+//! oracle version, exactly as the RFD prescribes.
+//!
+//! This crate is the *Web family's* producer, not an engine-wide text
+//! service: whether the n0 family shares a text artifact with it is the open
+//! D-M shaped-text stage ([`docs/wg/consolidation/n0-join-point.md`]), and
+//! building this crate as the anointed shared resolver would decide that
+//! join by construction. The Web producer depends on this crate; nothing
+//! here depends back.
+//!
+//! A module's identity is what it refuses. This one:
+//!
+//! - **owns no font discovery.** The environment is a manifest of exact
+//!   bytes handed in by the caller; there is no ambient font database, no
+//!   file read, no network. (`tests/architecture.rs` forbids the escape
+//!   hatches.)
+//! - **owns no render contract.** No resolved-frame types, no paint, no
+//!   backend. Glyph geometry leaves through [`OutlineSink`] in the node's
+//!   local y-down space, and a consumer lowers it into its own vocabulary.
+//! - **owns no clock and no estimate.** Resolution is a pure function of its
+//!   declared inputs; a width guessed before shaping is a different answer,
+//!   so no such guess exists here.
+//!
+//! [`docs/wg/feat-paragraph/text-layout.md`]: ../../../docs/wg/feat-paragraph/text-layout.md
+//! [`docs/wg/consolidation/n0-join-point.md`]: ../../../docs/wg/consolidation/n0-join-point.md
+
+mod artifact;
+mod environment;
+mod resolve;
+
+pub use artifact::{
+    BoundsBox, LineMetrics, OutlineSink, PlacedGlyph, ResolvedFace, ResolvedTextLayout,
+};
+pub use environment::{Environment, FontKey, FontResource};
+pub use resolve::{AttributedText, ResolveError, Style, resolve};
+
+/// The complete geometry-producing policy this crate currently implements.
+///
+/// Any change that can alter a glyph choice, position, metric, or bound —
+/// including a shaping-dependency upgrade that changes output, which is why
+/// the manifest pins the shaper exactly — requires a new version. A resolved
+/// artifact records the version that produced it; "latest" is not a durable
+/// identity.
+pub const ORACLE_VERSION: &str = "textlayout-v0";

--- a/crates/textlayout/src/resolve.rs
+++ b/crates/textlayout/src/resolve.rs
@@ -1,0 +1,278 @@
+//! Resolution: the one place attributed text becomes geometry.
+//!
+//! A pure function of its declared inputs. The same text, style, and
+//! environment always produce the same artifact; nothing ambient — no
+//! locale, no clock, no system font — can reach in.
+
+use std::sync::Arc;
+
+use crate::artifact::{BoundsBox, LineMetrics, PlacedGlyph, ResolvedFace, ResolvedTextLayout};
+use crate::environment::Environment;
+
+/// The complete layout-affecting style of the one run oracle v0 admits.
+#[derive(Clone, Debug)]
+pub struct Style {
+    /// Family name resolved against the environment's declared manifest —
+    /// exact match, no fallback.
+    pub family: String,
+    /// Font size in local px. Finite and positive, validated.
+    pub size: f32,
+}
+
+/// Attributed source at the v0 profile: one string under one complete style.
+/// The authoring layer owns document-level transformations — whitespace
+/// collapsing, entity expansion — and hands resolution the post-transform
+/// text; resolution never rewrites what it is given.
+#[derive(Clone, Debug)]
+pub struct AttributedText {
+    pub text: String,
+    pub style: Style,
+}
+
+/// Why resolution refused. Typed, named, and carrying the byte position
+/// where one exists — a consumer surfaces these at a stable node path.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResolveError {
+    /// `size` is not a finite positive number.
+    InvalidFontSize { size: f32 },
+    /// The declared family is not in the environment's manifest. There is
+    /// no system fallback to fall into; the diagnostic names the family so
+    /// the host can declare it.
+    UnknownFamily { family: String },
+    /// The environment's bytes for this family do not parse as a face.
+    UnparseableFace { family: String },
+    /// The face defines glyphs the v0 outline projection cannot honestly
+    /// realize — color or bitmap glyph tables whose ink is not the outline.
+    /// Streaming a monochrome placeholder for a color emoji is a silently
+    /// wrong pixel, so the face refuses whole; color faces arrive as a new
+    /// oracle version.
+    UnsupportedFaceFormat { family: String },
+    /// The character is outside oracle v0's admitted repertoire. The profile
+    /// is an explicit admit-list — printable ASCII — because everything
+    /// beyond it (a bidi control, a strong right-to-left letter, a line or
+    /// paragraph separator, a default-ignorable the shaper would silently
+    /// substitute) has semantics v0 does not implement, and shaping it
+    /// anyway would be approximation. The profile widens by oracle version;
+    /// until then the refusal names the byte.
+    UnsupportedCharacter { byte_index: usize, character: char },
+    /// The resolved face has no glyph for this cluster. v0 permits no
+    /// missing-glyph policy: no tofu, no substitution — a refusal naming
+    /// the source position.
+    MissingGlyph { byte_index: usize, character: char },
+    /// Shaping produced placement the v0 profile has no semantics for — a
+    /// glyph offset (mark attachment, positioning feature), a vertical pen
+    /// advance, or a negative advance. Dropping any of them would be
+    /// silently mispositioned ink, so the run refuses; richer placement
+    /// arrives as a new oracle version.
+    UnsupportedShaping { byte_index: usize },
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveError::InvalidFontSize { size } => {
+                write!(f, "font-size {size} is not a finite positive length")
+            }
+            ResolveError::UnknownFamily { family } => {
+                write!(
+                    f,
+                    "font family \"{family}\" is not in the declared environment"
+                )
+            }
+            ResolveError::UnparseableFace { family } => {
+                write!(
+                    f,
+                    "declared bytes for font family \"{family}\" do not parse as a face"
+                )
+            }
+            ResolveError::UnsupportedFaceFormat { family } => {
+                write!(
+                    f,
+                    "font family \"{family}\" carries color or bitmap glyphs outside the outline profile"
+                )
+            }
+            ResolveError::UnsupportedCharacter {
+                byte_index,
+                character,
+            } => write!(
+                f,
+                "character {character:?} at byte {byte_index} is outside the printable-ASCII v0 profile"
+            ),
+            ResolveError::MissingGlyph {
+                byte_index,
+                character,
+            } => write!(
+                f,
+                "no glyph for {character:?} at byte {byte_index} in the resolved face"
+            ),
+            ResolveError::UnsupportedShaping { byte_index } => write!(
+                f,
+                "shaping placed a glyph outside the one-run profile at byte {byte_index}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+/// Glyph tables whose ink is not the glyph outline. A face carrying any of
+/// them refuses whole: v0's projection is outlines, and realizing a color
+/// glyph as its monochrome fallback outline is a wrong pixel, not a policy.
+const NON_OUTLINE_GLYPH_TABLES: [&[u8; 4]; 5] = [b"COLR", b"CBDT", b"CBLC", b"sbix", b"SVG "];
+
+/// Resolve one attributed run against a declared environment into the
+/// immutable artifact, or refuse with a name.
+pub fn resolve(
+    text: &AttributedText,
+    env: &Environment,
+) -> Result<ResolvedTextLayout, ResolveError> {
+    let size = text.style.size;
+    if !size.is_finite() || size <= 0.0 {
+        return Err(ResolveError::InvalidFontSize { size });
+    }
+
+    // The profile guard is the resolver's property, not an accident of any
+    // font's coverage: an explicit admit-list, checked before shaping so the
+    // refusal names the source byte. Printable ASCII is the whole v0
+    // repertoire — everything else (bidi controls and strong RTL, Zl/Zp
+    // separators, default-ignorables the shaper would substitute unasked)
+    // refuses here rather than shaping approximately.
+    for (byte_index, character) in text.text.char_indices() {
+        if !matches!(character, ' '..='~') {
+            return Err(ResolveError::UnsupportedCharacter {
+                byte_index,
+                character,
+            });
+        }
+    }
+
+    let resource = env
+        .find(&text.style.family)
+        .ok_or_else(|| ResolveError::UnknownFamily {
+            family: text.style.family.clone(),
+        })?;
+    let face =
+        rustybuzz::Face::from_slice(&resource.bytes, resource.face_index).ok_or_else(|| {
+            ResolveError::UnparseableFace {
+                family: text.style.family.clone(),
+            }
+        })?;
+
+    // Raw table presence, deliberately independent of which tables the
+    // parser was compiled to interpret.
+    for tag in NON_OUTLINE_GLYPH_TABLES {
+        if face
+            .raw_face()
+            .table(rustybuzz::ttf_parser::Tag::from_bytes(tag))
+            .is_some()
+        {
+            return Err(ResolveError::UnsupportedFaceFormat {
+                family: text.style.family.clone(),
+            });
+        }
+    }
+
+    // rustybuzz reports upem as an i32 (the HarfBuzz convention); the value
+    // is a 16-bit font quantity, so a face outside that range is malformed.
+    let units_per_em =
+        u16::try_from(face.units_per_em()).map_err(|_| ResolveError::UnparseableFace {
+            family: text.style.family.clone(),
+        })?;
+    let scale = size / f32::from(units_per_em);
+    let metrics = LineMetrics {
+        ascent: f32::from(face.ascender()) * scale,
+        // ttf-parser reports descent as a negative distance; the artifact
+        // states it as a positive reach below the baseline.
+        descent: f32::from(-face.descender()) * scale,
+    };
+
+    let mut buffer = rustybuzz::UnicodeBuffer::new();
+    buffer.push_str(&text.text);
+    buffer.set_direction(rustybuzz::Direction::LeftToRight);
+    let shaped = rustybuzz::shape(&face, &[], buffer);
+
+    let mut glyphs = Vec::with_capacity(shaped.len());
+    let mut pen_x = 0.0f32;
+    for (info, pos) in shaped
+        .glyph_infos()
+        .iter()
+        .zip(shaped.glyph_positions().iter())
+    {
+        let byte_index = info.cluster as usize;
+        // Glyph 0 is .notdef: the face cannot render this cluster, and v0
+        // has no permitted replacement policy.
+        if info.glyph_id == 0 {
+            let character = text.text[byte_index..]
+                .chars()
+                .next()
+                .unwrap_or(char::REPLACEMENT_CHARACTER);
+            return Err(ResolveError::MissingGlyph {
+                byte_index,
+                character,
+            });
+        }
+        // v0's profile has offsets, vertical advances, and backward pens in
+        // no place. Dropping any of them would be silently mispositioned
+        // ink; each refuses instead.
+        if pos.x_offset != 0 || pos.y_offset != 0 || pos.y_advance != 0 || pos.x_advance < 0 {
+            return Err(ResolveError::UnsupportedShaping { byte_index });
+        }
+        // Glyph ids originate from the face's 16-bit space; a wider value
+        // is shaping output the profile cannot state.
+        let glyph_id = u16::try_from(info.glyph_id)
+            .map_err(|_| ResolveError::UnsupportedShaping { byte_index })?;
+        glyphs.push(PlacedGlyph {
+            glyph_id,
+            x: pen_x,
+            advance: pos.x_advance as f32 * scale,
+            cluster: info.cluster,
+        });
+        pen_x += pos.x_advance as f32 * scale;
+    }
+
+    let resolved_face = ResolvedFace {
+        key: resource.key,
+        face_index: resource.face_index,
+        units_per_em,
+    };
+    let ink_bounds = ink_union(&face, &glyphs, scale);
+
+    Ok(ResolvedTextLayout::new(
+        text.text.clone(),
+        resolved_face,
+        size,
+        metrics,
+        glyphs,
+        pen_x,
+        ink_bounds,
+        Arc::clone(&resource.bytes),
+    ))
+}
+
+/// The tight union of glyph bounding boxes in local y-down px. Uses the
+/// face's own extents (curve extrema are the font's, already tight for the
+/// outlines shaping selected).
+fn ink_union(face: &rustybuzz::Face<'_>, glyphs: &[PlacedGlyph], scale: f32) -> Option<BoundsBox> {
+    let mut union: Option<(f32, f32, f32, f32)> = None;
+    for glyph in glyphs {
+        let Some(rect) = face.glyph_bounding_box(rustybuzz::ttf_parser::GlyphId(glyph.glyph_id))
+        else {
+            continue; // no ink: advance only
+        };
+        // Font units are y-up: y_max maps to the box top (negative y).
+        let x0 = glyph.x + f32::from(rect.x_min) * scale;
+        let x1 = glyph.x + f32::from(rect.x_max) * scale;
+        let y0 = -f32::from(rect.y_max) * scale;
+        let y1 = -f32::from(rect.y_min) * scale;
+        union = Some(match union {
+            None => (x0, y0, x1, y1),
+            Some((ux0, uy0, ux1, uy1)) => (ux0.min(x0), uy0.min(y0), ux1.max(x1), uy1.max(y1)),
+        });
+    }
+    union.map(|(x0, y0, x1, y1)| BoundsBox {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    })
+}

--- a/crates/textlayout/tests/architecture.rs
+++ b/crates/textlayout/tests/architecture.rs
@@ -1,0 +1,104 @@
+//! The crate's identity, enforced: `textlayout` owns shaping, metrics, and
+//! the resolved artifact — and refuses font discovery, render contracts,
+//! backends, clocks, and every ambient input. A dependency or source line
+//! that violates the refusal fails here before it can ship.
+
+use std::fs;
+use std::path::Path;
+
+/// The complete permitted dependency perimeter, across every dependency
+/// table shape a manifest can declare (plain, dev, build, target-specific).
+/// Growing it is a decision, not a convenience — state the refusal the new
+/// edge does not violate.
+#[test]
+fn dependency_perimeter_is_exactly_rustybuzz() {
+    let manifest = fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml")).unwrap();
+
+    let mut in_dependency_section = false;
+    let mut deps = Vec::new();
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            // Any section whose header names dependencies counts:
+            // [dependencies], [dev-dependencies], [build-dependencies],
+            // [target.'cfg(...)'.dependencies], and their dotted-key forms.
+            in_dependency_section = line.contains("dependencies");
+            continue;
+        }
+        if !in_dependency_section || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(name) = line.split(['=', ' ']).next() {
+            deps.push(name.to_string());
+        }
+    }
+    assert_eq!(
+        deps,
+        vec!["rustybuzz".to_string()],
+        "textlayout's dependency perimeter changed; every edge must be a decision"
+    );
+
+    // A build script is a dependency-shaped hole the manifest scan cannot
+    // see; the crate declares none.
+    assert!(
+        !Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/build.rs")).exists(),
+        "textlayout must not gain a build script"
+    );
+}
+
+/// No ambient font access, no render contract, no backend, no clock, no I/O
+/// — enforced as a whole-file scan like the sibling locks, so nothing hides
+/// in a comment, a doctest, or a brace import. Prose in `src/` therefore
+/// names refusals descriptively, never by token.
+#[test]
+fn source_refuses_ambient_and_backend_reach() {
+    const FORBIDDEN: &[&str] = &[
+        // Ambient font discovery — the environment is a manifest of bytes.
+        "fontdb",
+        "core_text",
+        "CoreText",
+        "dwrite",
+        "fontconfig",
+        // Render contracts and backends stay out of the resolver.
+        "rframe",
+        "websem",
+        "n0_model",
+        "csscascade",
+        "stylo",
+        "skia",
+        // Ambient inputs: resolution is a pure function of declared inputs.
+        "std::fs",
+        "std::net",
+        "std::env",
+        "std::time",
+        "std::io",
+        "SystemTime",
+        "Instant",
+        // Brace and glob imports could smuggle any of the above past a
+        // path-shaped needle; single-path imports only.
+        "use std::{",
+        "use std::*",
+    ];
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut stack = vec![src];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                let source = fs::read_to_string(&path).unwrap();
+                for token in FORBIDDEN {
+                    assert!(
+                        !source.contains(token),
+                        "{} reaches for {token}, which textlayout refuses",
+                        path.display()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/textlayout/tests/oracle_v0.rs
+++ b/crates/textlayout/tests/oracle_v0.rs
@@ -1,0 +1,243 @@
+//! Oracle v0 against measured ground truth.
+//!
+//! The numbers here are not derived from this crate: they were measured from
+//! the pinned Ahem bytes (fixtures/web-first/fonts/ahem.ttf) and verified
+//! byte-exact against Chromium 149 during the text-0 probe rounds and the
+//! engine-side crux spike (docs/wg/consolidation/text-oracle.md). If this
+//! crate disagrees with them, the crate is wrong.
+
+use std::sync::Arc;
+
+use textlayout::{
+    AttributedText, Environment, FontKey, FontResource, OutlineSink, ResolveError, Style, resolve,
+};
+
+const AHEM: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../fixtures/web-first/fonts/ahem.ttf"
+);
+
+/// Tests exercise resolution, not host-side digest verification, so the key
+/// is a stand-in identity the artifact must nonetheless carry through.
+const TEST_KEY: FontKey = FontKey::new([0xAB; 32]);
+
+fn ahem_environment() -> Environment {
+    let bytes: Arc<[u8]> = std::fs::read(AHEM).expect("pinned Ahem bytes").into();
+    Environment::new(vec![FontResource {
+        key: TEST_KEY,
+        family: "Ahem".to_string(),
+        face_index: 0,
+        bytes,
+    }])
+}
+
+fn ahem(text: &str, size: f32) -> AttributedText {
+    AttributedText {
+        text: text.to_string(),
+        style: Style {
+            family: "Ahem".to_string(),
+            size,
+        },
+    }
+}
+
+#[test]
+fn x_at_50_resolves_the_measured_em_box() {
+    let layout = resolve(&ahem("X", 50.0), &ahem_environment()).unwrap();
+
+    assert_eq!(layout.oracle_version(), textlayout::ORACLE_VERSION);
+    assert_eq!(layout.face().key, TEST_KEY);
+    assert_eq!(layout.face().units_per_em, 1000);
+
+    // Measured: 'X' is glyph 58, advance 1000 font units.
+    let glyphs = layout.glyphs();
+    assert_eq!(glyphs.len(), 1);
+    assert_eq!(glyphs[0].glyph_id, 58);
+    assert_eq!(glyphs[0].x, 0.0);
+    assert_eq!(glyphs[0].advance, 50.0);
+    assert_eq!(glyphs[0].cluster, 0);
+    assert_eq!(layout.advance(), 50.0);
+
+    // Ahem: ascent 800, descent -200, every metric policy agreeing.
+    assert_eq!(layout.metrics().ascent, 40.0);
+    assert_eq!(layout.metrics().descent, 10.0);
+
+    // The em box in y-down local px: 0.8em above the baseline, 0.2em below.
+    let ink = layout.ink_bounds().unwrap();
+    assert_eq!(
+        (ink.x, ink.y, ink.width, ink.height),
+        (0.0, -40.0, 50.0, 50.0)
+    );
+    let logical = layout.logical_bounds();
+    assert_eq!(
+        (logical.x, logical.y, logical.width, logical.height),
+        (0.0, -40.0, 50.0, 50.0)
+    );
+}
+
+#[test]
+fn space_advances_without_ink() {
+    let layout = resolve(&ahem("X X", 20.0), &ahem_environment()).unwrap();
+
+    // Measured: gids [58, 3, 58], each advancing exactly one em.
+    let glyphs = layout.glyphs();
+    assert_eq!(glyphs.len(), 3);
+    assert_eq!(
+        glyphs.iter().map(|g| g.glyph_id).collect::<Vec<_>>(),
+        vec![58, 3, 58]
+    );
+    assert_eq!(
+        glyphs.iter().map(|g| g.x).collect::<Vec<_>>(),
+        vec![0.0, 20.0, 40.0]
+    );
+    assert_eq!(layout.advance(), 60.0);
+    assert_eq!(
+        glyphs.iter().map(|g| g.cluster).collect::<Vec<_>>(),
+        vec![0, 1, 2]
+    );
+
+    // Ink spans both boxes; the space contributes advance only.
+    let ink = layout.ink_bounds().unwrap();
+    assert_eq!(
+        (ink.x, ink.y, ink.width, ink.height),
+        (0.0, -16.0, 60.0, 20.0)
+    );
+
+    // The space glyph refuses to stream an outline.
+    let mut sink = CollectSink::default();
+    assert!(!layout.outline(1, &mut sink));
+    assert!(sink.points.is_empty() && sink.moves == 0 && sink.closes == 0);
+}
+
+#[test]
+fn outline_streams_the_flipped_box() {
+    let layout = resolve(&ahem("X", 50.0), &ahem_environment()).unwrap();
+    let mut sink = CollectSink::default();
+    assert!(layout.outline(0, &mut sink));
+
+    // One rectangular contour: a move, straight lines, one close.
+    assert_eq!(sink.moves, 1);
+    assert!(sink.lines >= 3, "a box outline draws at least three sides");
+    assert_eq!(sink.closes, 1);
+    assert_eq!(sink.curves, 0, "Ahem's box has no curves");
+
+    // Every vertex lies on the em box's edges in y-down px — the y-flip is
+    // the classic silent-wrong-pixel trap, so it is pinned here.
+    for &(x, y) in &sink.points {
+        assert!(x == 0.0 || x == 50.0, "vertex x {x} off the box");
+        assert!(
+            y == -40.0 || y == 10.0,
+            "vertex y {y} off the box (flip broken?)"
+        );
+    }
+    let xs: Vec<f32> = sink.points.iter().map(|p| p.0).collect();
+    let ys: Vec<f32> = sink.points.iter().map(|p| p.1).collect();
+    assert!(xs.contains(&0.0) && xs.contains(&50.0));
+    assert!(ys.contains(&-40.0) && ys.contains(&10.0));
+}
+
+/// In-process purity only: cross-run and cross-upgrade stability is pinned
+/// by the measured-ground-truth assertions above and the exact shaper pin.
+#[test]
+fn resolution_is_deterministic() {
+    let env = ahem_environment();
+    let text = ahem("X X", 20.0);
+    let first = resolve(&text, &env).unwrap();
+    let second = resolve(&text, &env).unwrap();
+    assert_eq!(first.glyphs(), second.glyphs());
+    assert_eq!(first.advance(), second.advance());
+    assert_eq!(first.ink_bounds(), second.ink_bounds());
+    assert_eq!(first.metrics(), second.metrics());
+}
+
+#[test]
+fn empty_text_resolves_to_metrics_without_glyphs() {
+    let layout = resolve(&ahem("", 20.0), &ahem_environment()).unwrap();
+    assert!(layout.glyphs().is_empty());
+    assert_eq!(layout.advance(), 0.0);
+    assert!(layout.ink_bounds().is_none());
+    // The empty run still carries the line's typographic extent.
+    assert_eq!(layout.logical_bounds().height, 20.0);
+}
+
+#[test]
+fn undeclared_family_refuses_by_name() {
+    let err = resolve(&ahem("X", 20.0), &Environment::default()).unwrap_err();
+    assert_eq!(
+        err,
+        ResolveError::UnknownFamily {
+            family: "Ahem".to_string()
+        }
+    );
+}
+
+#[test]
+fn the_profile_is_the_resolvers_property_not_the_fonts() {
+    // Every class of out-of-profile character refuses by position at the
+    // admit-list, before any font's coverage can decide differently:
+    // a control, a strong-RTL letter, a bidi override, a Zl separator, a
+    // default-ignorable the shaper would silently substitute, and an emoji.
+    for (text, byte_index, character) in [
+        ("X\nX", 1, '\n'),
+        ("X\u{05D0}", 1, '\u{05D0}'),
+        ("ab\u{202E}cd", 2, '\u{202E}'),
+        ("a\u{2028}b", 1, '\u{2028}'),
+        ("X\u{200B}Y", 1, '\u{200B}'),
+        ("X\u{00AD}Y", 1, '\u{00AD}'),
+        ("X\u{1F600}", 1, '\u{1F600}'),
+    ] {
+        let err = resolve(&ahem(text, 20.0), &ahem_environment()).unwrap_err();
+        assert_eq!(
+            err,
+            ResolveError::UnsupportedCharacter {
+                byte_index,
+                character
+            },
+            "{text:?} must refuse at the profile guard"
+        );
+    }
+}
+
+// MissingGlyph is unreachable through Ahem at the v0 profile — Ahem covers
+// all of printable ASCII — so its pin arrives with the first environment
+// font that does not, rather than pretending a reachable test exists today.
+
+#[test]
+fn invalid_sizes_refuse() {
+    let env = ahem_environment();
+    for size in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+        let err = resolve(&ahem("X", size), &env).unwrap_err();
+        assert!(matches!(err, ResolveError::InvalidFontSize { .. }));
+    }
+}
+
+#[derive(Default)]
+struct CollectSink {
+    moves: usize,
+    lines: usize,
+    curves: usize,
+    closes: usize,
+    points: Vec<(f32, f32)>,
+}
+
+impl OutlineSink for CollectSink {
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.moves += 1;
+        self.points.push((x, y));
+    }
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.lines += 1;
+        self.points.push((x, y));
+    }
+    fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32) {
+        self.curves += 1;
+        self.points.extend([(x1, y1), (x, y)]);
+    }
+    fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32) {
+        self.curves += 1;
+        self.points.extend([(x1, y1), (x2, y2), (x, y)]);
+    }
+    fn close(&mut self) {
+        self.closes += 1;
+    }
+}

--- a/docs/wg/consolidation/index.md
+++ b/docs/wg/consolidation/index.md
@@ -71,7 +71,7 @@ that decision is settled:
 | [how the mature Web renderer enters](./web-renderer-adoption.md) | patrol | (evidence for D-M) | which capability is reusable, which topology must not cross |
 | [the SVG engine of record](./svg-engine-of-record.md) | finding | D-N — the n0 path is the one product path for SVG, static and animated | **taken** 2026-07-24; settles routing and succession, not capability |
 | [the conformance-bar flip rule](./flip-rule.md) | proposal | FLIP — thresholds, coverage, oracle discipline | **unratified** ([gridaco/nothing#49](https://github.com/gridaco/nothing/issues/49)); **no score may be produced or inspected** |
-| [the text oracle method](./text-oracle.md) | proposal | how text is gated on the engine of record: the deterministic-font rung, the admitted numeric domain, the corpus-growth law | **proposed**; decides no code and leaves the D-M text stage open |
+| [the text oracle method](./text-oracle.md) | finding | how text is gated on the engine of record: the deterministic-font rung, the admitted numeric domain, the hermetic font environment, the corpus-growth law | **ratified** 2026-08-04 ([gridaco/nothing#68](https://github.com/gridaco/nothing/pull/68)); binds the text rungs, leaves the D-M text stage open |
 | [lock-graph-changes.toml](./lock-graph-changes.toml) | gate ledger | (records moves D-L authorises) | read by `bin/check-cargo-lock-additions-only` |
 
 D-N demotes the mature Web renderer to a frozen semantics donor, with declared

--- a/docs/wg/consolidation/text-oracle.md
+++ b/docs/wg/consolidation/text-oracle.md
@@ -12,7 +12,10 @@ format: md
 
 # The text oracle method
 
-**Status: proposed.** This brief is the text-0 milestone: it puts the *method*
+**Status: ratified 2026-08-04** ([gridaco/nothing#68](https://github.com/gridaco/nothing/pull/68)).
+Its decisions bind the text arc's rungs; the D-M shaped-text stage remains
+open, and text-2 is the spike that closes it.
+This brief is the text-0 milestone: it puts the *method*
 for gating text on the SVG engine of record (`websem → rframe → n0`) before
 the owner, with the Chromium probe record that grounds it. It decides no code
 and touches no open decision — the D-M shaped-text stage in


### PR DESCRIPTION
The first code rung of the text arc ([gridaco/nothing#69](https://github.com/gridaco/nothing/issues/69)), executing against the method ratified in #68. It builds the **second real text producer** — the thing D-M's shaped-text stage has been gated on since it was recorded.

## What this is

`crates/textlayout` — the Web family's text resolution oracle, implementing the [text-layout RFD](https://github.com/gridaco/nothing/blob/main/docs/wg/feat-paragraph/text-layout.md) at its smallest honest profile:

```
attributed text + explicit font environment -> resolved text layout | typed refusal   (oracle v0)
```

## Why an artifact, not a shaping helper

The obvious build — shape, flatten to outlines, done — lands correct pixels and **unlocks nothing**. D-M asks whether a neutral *shaped-text representation and font-key boundary* can be produced by both engines; outlines are geometry that deliberately carries no font identity at all. A producer that discards its shaped-text artifact is not a second producer in the D-M sense, and the discovery would come at text-2 with nothing to push against n0's artifact.

So the artifact exists and is inspectable inside the producer, even though it never crosses `rframe`. Outline lowering is its first *consumer*.

Equally deliberate: this is the **Web family's** producer, not an engine-wide text service. Building it as the anointed shared resolver would decide D-M *high* by construction and make text-2 theater. The dependency direction is `websem -> textlayout` only; join-low stays a live outcome.

## The profile, and what it refuses

v0 resolves one style run of printable-ASCII, horizontal, LTR text — no wrapping, fallback, or synthesis. The repertoire is an **explicit admit-list enforced by the resolver**, so out-of-profile input refuses by byte position regardless of what any font happens to cover. Refusals: unknown family, unparseable face, color/bitmap face, out-of-profile character, missing glyph, out-of-profile shaping (offsets, vertical advance, negative advance), invalid size.

Identity locked by architecture tests: perimeter exactly `{rustybuzz}` across every dependency-table shape plus no build script; no ambient font database, render contract, backend, clock, or I/O in `src`.

## Verified adversarially

Three reviewers with distinct lenses (RFD conformance, correctness, repo laws) were prompted to refute the crate, and did — against fonts outside the fixture corpus. Every must-fix is folded in:

- **The profile was enforced by Ahem's coverage, not by the resolver.** Hebrew resolved un-reordered against a covering font; U+202E RLO passed the `is_control()` guard (Cf, not Cc) and entered the artifact as a phantom space glyph; U+2028 evaded the line-terminator claim; ZWSP/soft-hyphen were silently substituted by the shaper's hide-default-ignorables pass. The admit-list closed all six at once.
- **`y_advance` and negative advances were dropped**, flattening GPOS vertical pen movement onto the baseline.
- **Color/bitmap faces resolved to monochrome placeholder outlines** — demonstrated with Apple Color Emoji. Now refused whole by raw table tag.
- **`outline()` accepted any caller-built glyph**, so a glyph id from another font could be streamed through this artifact's face. Now index-based over recorded placements.
- Glyph-id panic → typed refusal; rustybuzz pinned `=0.20.1` so `ORACLE_VERSION`'s stability claim is mechanical; both architecture locks hardened; `FontKey`'s doc no longer claims a verification it does not perform.

Declined with reasons recorded: in-crate hashing (a sha2 perimeter edge is an owner decision; the brief assigns verification to the host, gated when `n0_cli --font` lands), a `MissingGlyph` test (unreachable through Ahem over ASCII — an honest comment beats a fake pin), line-gap in `LineMetrics` (declared deferral).

## Ground truth

Tests assert the numbers measured in the text-0 probe rounds and the crux spike — glyph 58, 1000-unit advances, the 0.8/0.2 em split, the y-flip vertices — not values derived from this crate. Lock delta is pure addition.

Also promotes the text-oracle brief to **ratified** now that #68 has merged.

Next in the arc: the websem `<text>` arm consuming this crate, then the text cells and `svg-text` graduation.