### PR TITLE
text-1c: declare fonts with `--font`, and render text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,7 +3336,9 @@ dependencies = [
  "math2",
  "n0",
  "rframe",
+ "sha2",
  "skia-safe",
+ "textlayout",
  "websem",
 ]
 

--- a/crates/n0_cli/Cargo.toml
+++ b/crates/n0_cli/Cargo.toml
@@ -20,6 +20,10 @@ websem = { path = "../websem" }
 n0 = { path = "../n0" }
 math2 = { path = "../math2" }
 rframe = { path = "../rframe" }
+# The host declares the fonts text resolves against, and verifies their
+# bytes against the declared digest before any pixel exists.
+textlayout = { path = "../textlayout" }
+sha2 = "0.10"
 skia-safe = { version = "=0.99.0", features = [
   "gpu",
   "gl",

--- a/crates/n0_cli/README.md
+++ b/crates/n0_cli/README.md
@@ -29,6 +29,12 @@ cargo run -p n0_cli --bin n0 -- \
   fixtures/web-first/animation/svg-scene-cub-animation.svg /tmp/cub-1s.png 96x96 \
   --time-ns 1000000000
 
+# text: the font is a declared, verified input of the render — the family
+# names bytes, and the bytes are checked before any pixel
+cargo run -p n0_cli --bin n0 -- \
+  fixtures/web-first/text/svg-text-em-box.svg /tmp/text.png 100x100 \
+  --font Ahem=fixtures/web-first/fonts/ahem.ttf@sha256:b719ecb31c5b21fc573c03f6421c74ac63c271a5a3ff841e34f9705fb94b8448
+
 # dev harness: refuse on the first beyond-slice construct instead of
 # rendering best-effort with declared degradations (the default)
 cargo run -p n0_cli --bin n0 -- \
@@ -135,6 +141,36 @@ cargo run -p n0_cli --bin n0 -- \
   attribute refuses the paint), font-relative units in gradient geometry,
   a percentage in a gradient's computed transform (Chromium resolves it
   against mismatched spaces), an external reference, and `<pattern>`.
+  `<text>` is consumed (the text rung), and its font environment is the
+  host's: text resolves only against fonts declared with
+  `--font FAMILY=PATH@sha256:HEX` (repeatable), whose bytes are **verified
+  against the declared digest before any pixel exists** — a family name is
+  not a font identity, and a mismatch refuses the render rather than
+  producing a silently different one. A `<text>` run whose family was never
+  declared refuses by name; there is no system fallback, no ambient face,
+  and therefore no machine-local pixel anywhere on this path. Inside that
+  environment one run resolves once through
+  [the text oracle](../../docs/wg/feat-paragraph/text-layout.md) at its v0
+  profile — one style run of printable ASCII, horizontal and
+  left-to-right, no wrapping and no fallback — and its glyph outlines lower
+  to the contract's ordinary path facts, so no font identity crosses into
+  the resolved frame. `x`, `y`, and the `text-anchor` attribute
+  (`start`/`middle`/`end`) place the run; `font-family` and `font-size`
+  come from the one cascade, where an author rule beats the presentation
+  attribute exactly as Chromium measured. Geometry is admitted only inside
+  the ratified [numeric domain](../../docs/wg/consolidation/text-oracle.md)
+  — integer position, a `font-size` that is an integer multiple of 5, an
+  integer anchor-resolved start — because that is where every rasterizer's
+  per-pixel coverage is 0 or 1 and the byte-exact gate holds; Chromium
+  snaps everything else by a rasterizer-internal rule, and this refuses by
+  name instead of codifying it. What refuses by name: the CSS spelling of
+  `text-anchor` (Chromium consumes it from the cascade, the pinned Stylo
+  build has no such longhand — a silent drop before the rung), a generic
+  family (which names no declared font), `<tspan>` and any other element
+  child, `dx`/`dy`/`rotate` lists, `textLength`, decorations, letter and
+  word spacing, writing mode and direction, stroke on text, a colour or
+  bitmap face, and any character outside the v0 repertoire. The inline-HTML
+  entry declares no fonts, so its `<text>` refuses there.
   `display: none` and `visibility` are consumed from the one cascade
   (attribute and CSS spellings alike): a pruned or hidden element renders
   the correct nothing rather than a declared hole, a `visibility: visible`

--- a/crates/n0_cli/src/fonts.rs
+++ b/crates/n0_cli/src/fonts.rs
@@ -1,0 +1,179 @@
+//! The host's font declarations: `--font FAMILY=PATH@sha256:HEX`.
+//!
+//! A family name is not a font identity — the same name resolves to
+//! different bytes on different machines — so a declaration carries the
+//! digest of the bytes it means, and the host **verifies before rendering**.
+//! A mismatch refuses; it never becomes a silently different pixel.
+//!
+//! This is the host side of the hermetic environment the ratified
+//! [text-oracle method](../../../docs/wg/consolidation/text-oracle.md)
+//! requires. The engine never reads a font file and never consults an
+//! ambient font database: the environment it resolves against is exactly
+//! what was declared here, and an undeclared family refuses by name.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+
+/// One parsed `--font` declaration, before its bytes are read.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FontDeclaration {
+    pub(crate) family: String,
+    pub(crate) path: String,
+    /// Lowercase hex SHA-256 of the bytes this declaration means.
+    pub(crate) digest: String,
+}
+
+/// Parse one `FAMILY=PATH@sha256:HEX`.
+///
+/// The family is everything before the first `=`, the digest everything
+/// after the last `@sha256:` — so a path may contain `=` and `@`, and only
+/// the exact digest marker terminates it.
+pub(crate) fn parse_declaration(spec: &str) -> Result<FontDeclaration, String> {
+    const MARKER: &str = "@sha256:";
+    let Some((family, rest)) = spec.split_once('=') else {
+        return Err(format!(
+            "font declaration {spec:?} must look like FAMILY=PATH@sha256:HEX"
+        ));
+    };
+    if family.is_empty() {
+        return Err(format!("font declaration {spec:?} names no family"));
+    }
+    let Some(marker_at) = rest.rfind(MARKER) else {
+        return Err(format!(
+            "font declaration {spec:?} carries no @sha256: digest — a family name is not a font \
+             identity, so the bytes it means are declared and verified"
+        ));
+    };
+    let path = &rest[..marker_at];
+    let digest = &rest[marker_at + MARKER.len()..];
+    if path.is_empty() {
+        return Err(format!("font declaration {spec:?} names no path"));
+    }
+    if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!(
+            "font declaration {spec:?} carries {digest:?}, which is not a 64-character hex SHA-256"
+        ));
+    }
+    Ok(FontDeclaration {
+        family: family.to_string(),
+        path: path.to_string(),
+        digest: digest.to_ascii_lowercase(),
+    })
+}
+
+/// Read and verify every declaration into the engine's font environment.
+///
+/// Verification is not advisory: bytes whose digest differs from the
+/// declaration are refused here, before a frame exists, so no render can
+/// proceed against a font the host did not mean.
+pub(crate) fn load_environment(
+    declarations: &[FontDeclaration],
+) -> Result<textlayout::Environment, String> {
+    let mut resources = Vec::with_capacity(declarations.len());
+    for declaration in declarations {
+        let bytes = std::fs::read(Path::new(&declaration.path))
+            .map_err(|error| format!("cannot read font {}: {error}", declaration.path))?;
+        let actual = format!("{:x}", Sha256::digest(&bytes));
+        if actual != declaration.digest {
+            return Err(format!(
+                "font {} is not the declared identity: expected sha256 {}, read {actual}",
+                declaration.path, declaration.digest
+            ));
+        }
+        let mut digest = [0u8; 32];
+        for (index, slot) in digest.iter_mut().enumerate() {
+            *slot = u8::from_str_radix(&actual[index * 2..index * 2 + 2], 16)
+                .expect("hex from a hex formatter");
+        }
+        resources.push(textlayout::FontResource {
+            key: textlayout::FontKey::new(digest),
+            family: declaration.family.clone(),
+            face_index: 0,
+            bytes: Arc::from(bytes),
+        });
+    }
+    Ok(textlayout::Environment::new(resources))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEX: &str = "b719ecb31c5b21fc573c03f6421c74ac63c271a5a3ff841e34f9705fb94b8448";
+
+    #[test]
+    fn a_well_formed_declaration_parses() {
+        let parsed = parse_declaration(&format!("Ahem=fixtures/ahem.ttf@sha256:{HEX}")).unwrap();
+        assert_eq!(
+            parsed,
+            FontDeclaration {
+                family: "Ahem".to_string(),
+                path: "fixtures/ahem.ttf".to_string(),
+                digest: HEX.to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_path_may_carry_the_delimiters() {
+        // Only the *last* `@sha256:` terminates the path, and only the first
+        // `=` ends the family — so awkward real paths still parse.
+        let parsed =
+            parse_declaration(&format!("My Font=/tmp/a=b@1/font.ttf@sha256:{HEX}")).unwrap();
+        assert_eq!(parsed.family, "My Font");
+        assert_eq!(parsed.path, "/tmp/a=b@1/font.ttf");
+    }
+
+    #[test]
+    fn an_undeclared_digest_refuses() {
+        let error = parse_declaration("Ahem=fixtures/ahem.ttf").unwrap_err();
+        assert!(error.contains("a family name is not a font identity"));
+    }
+
+    #[test]
+    fn a_malformed_digest_refuses() {
+        for spec in [
+            format!("Ahem=f.ttf@sha256:{}", &HEX[..63]),
+            format!("Ahem=f.ttf@sha256:{}z", &HEX[..63]),
+            "Ahem=f.ttf@sha256:".to_string(),
+        ] {
+            let error = parse_declaration(&spec).unwrap_err();
+            assert!(error.contains("hex SHA-256"), "{spec}: {error}");
+        }
+    }
+
+    #[test]
+    fn an_empty_family_or_path_refuses() {
+        assert!(parse_declaration(&format!("=f.ttf@sha256:{HEX}")).is_err());
+        assert!(parse_declaration(&format!("Ahem=@sha256:{HEX}")).is_err());
+    }
+
+    #[test]
+    fn the_pinned_gate_font_verifies_and_a_wrong_digest_does_not() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let path = root
+            .join("fixtures/web-first/fonts/ahem.ttf")
+            .display()
+            .to_string();
+
+        let environment = load_environment(&[FontDeclaration {
+            family: "Ahem".to_string(),
+            path: path.clone(),
+            digest: HEX.to_string(),
+        }])
+        .expect("the pinned bytes match their recorded digest");
+        assert_eq!(environment.fonts().len(), 1);
+        assert_eq!(environment.fonts()[0].family, "Ahem");
+
+        let wrong = "0".repeat(64);
+        let error = load_environment(&[FontDeclaration {
+            family: "Ahem".to_string(),
+            path,
+            digest: wrong,
+        }])
+        .expect_err("a font that is not the declared identity must refuse before rendering");
+        assert!(error.contains("is not the declared identity"));
+    }
+}

--- a/crates/n0_cli/src/main.rs
+++ b/crates/n0_cli/src/main.rs
@@ -36,12 +36,19 @@
 //! images and external stylesheets are not resolved; directory input and
 //! non-PNG output remain outside the admitted host contract.
 //!
+//! Text resolves against fonts the host declares, never an ambient one:
+//! `--font FAMILY=PATH@sha256:HEX` (repeatable) names the exact bytes a
+//! family means, and the host verifies them before any pixel. A `<text>`
+//! run whose family was not declared refuses by name — there is no system
+//! fallback to render a machine-local pixel from.
+//!
 //! Usage:
 //!   cargo run -p n0_cli --bin n0 -- <input.svg|input.html> <out.png> <WxH>
 //!   cargo run -p n0_cli --bin n0 -- <input.svg|input.html> <out.png> <WxH> --base
 //!   cargo run -p n0_cli --bin n0 -- <input.svg|input.html> <out.png> <WxH> --time-ns <i64>
 //!   ... any form plus --strict (refuse beyond-slice) or --best-effort (the
-//!   explicit spelling of the default)
+//!   explicit spelling of the default), and any number of
+//!   --font FAMILY=PATH@sha256:HEX
 //!
 //! Examples:
 //!   cargo run -p n0_cli --bin n0 -- \
@@ -50,6 +57,8 @@
 //!     fixtures/web-first/animation/svg-rect-x-animation.svg /tmp/t1s.png 64x32 --time-ns 1000000000
 //!   cargo run -p n0_cli --bin n0 -- \
 //!     fixtures/web-first/animation/svg-scene-cub-animation.svg /tmp/cub.png 96x96 --strict
+
+mod fonts;
 
 use std::path::Path;
 use std::process::ExitCode;
@@ -84,14 +93,15 @@ enum Admission {
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    if !matches!(args.len(), 3..=6) {
+    if args.len() < 3 {
         eprintln!(
             "usage:\n\
              n0 <input.svg|input.html> <out.png> <WxH>\n\
              n0 <input.svg|input.html> <out.png> <WxH> --base\n\
              n0 <input.svg|input.html> <out.png> <WxH> --time-ns <signed-nanoseconds>\n\
              any form may add --strict (refuse beyond-slice constructs)\n\
-             or --best-effort (declare and render; the default)"
+             or --best-effort (declare and render; the default),\n\
+             and any number of --font FAMILY=PATH@sha256:HEX"
         );
         return ExitCode::from(2);
     }
@@ -101,8 +111,17 @@ fn main() -> ExitCode {
         eprintln!("error: size must look like 128x128 and be positive");
         return ExitCode::from(2);
     };
-    let (policy, admission) = match parse_render_options(&args[3..]) {
+    let (policy, admission, font_declarations) = match parse_render_options(&args[3..]) {
         Ok(options) => options,
+        Err(message) => {
+            eprintln!("error: {message}");
+            return ExitCode::from(2);
+        }
+    };
+    // Verified before a frame exists: a font that is not the declared
+    // identity can never reach a pixel.
+    let font_environment = match fonts::load_environment(&font_declarations) {
+        Ok(environment) => environment,
         Err(message) => {
             eprintln!("error: {message}");
             return ExitCode::from(2);
@@ -129,13 +148,14 @@ fn main() -> ExitCode {
         }
     };
 
-    let (png, degradations) = match render_source_to_png(&source, kind, w, h, policy, admission) {
-        Ok(rendered) => rendered,
-        Err(e) => {
-            eprintln!("error: render failed: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
+    let (png, degradations) =
+        match render_source_to_png(&source, kind, w, h, policy, admission, font_environment) {
+            Ok(rendered) => rendered,
+            Err(e) => {
+                eprintln!("error: render failed: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
 
     if let Err(e) = std::fs::write(output, &png) {
         eprintln!("error: cannot write {output}: {e}");
@@ -173,10 +193,23 @@ impl FramePolicy {
 /// Parse the trailing options: an optional frame policy (`--base` or
 /// `--time-ns <ns>`) and an optional admission (`--strict` or
 /// `--best-effort`), in any order.
-fn parse_render_options(args: &[String]) -> Result<(FramePolicy, Admission), String> {
+fn parse_render_options(
+    args: &[String],
+) -> Result<(FramePolicy, Admission, Vec<fonts::FontDeclaration>), String> {
     let mut admission = None;
     let mut policy_args = Vec::new();
+    let mut declarations = Vec::new();
+    let mut expecting_font = false;
     for arg in args {
+        if expecting_font {
+            declarations.push(fonts::parse_declaration(arg)?);
+            expecting_font = false;
+            continue;
+        }
+        if arg == "--font" {
+            expecting_font = true;
+            continue;
+        }
         let flag = match arg.as_str() {
             "--strict" => Some(Admission::Strict),
             "--best-effort" => Some(Admission::BestEffort),
@@ -190,8 +223,15 @@ fn parse_render_options(args: &[String]) -> Result<(FramePolicy, Admission), Str
             None => policy_args.push(arg.clone()),
         }
     }
+    if expecting_font {
+        return Err("--font needs a FAMILY=PATH@sha256:HEX declaration".to_string());
+    }
     let policy = parse_frame_policy(&policy_args)?;
-    Ok((policy, admission.unwrap_or(Admission::BestEffort)))
+    Ok((
+        policy,
+        admission.unwrap_or(Admission::BestEffort),
+        declarations,
+    ))
 }
 
 fn parse_frame_policy(args: &[String]) -> Result<FramePolicy, String> {
@@ -239,6 +279,7 @@ fn has_extension(path: &Path, expected: &str) -> bool {
 /// Render one source through the engine of record and return the PNG plus
 /// the degradations relevant to this request: skips always apply, a
 /// samples-as-base declaration only describes `--time-ns` requests.
+#[allow(clippy::too_many_arguments)]
 fn render_source_to_png(
     source: &str,
     kind: SourceKind,
@@ -246,17 +287,24 @@ fn render_source_to_png(
     height: i32,
     policy: FramePolicy,
     admission: Admission,
+    fonts: textlayout::Environment,
 ) -> Result<(Vec<u8>, Vec<websem::Degradation>), String> {
     // The requested raster is the initial viewport (SVG2 §8.2) a standalone
     // document resolves auto sizing against — the CLI's WxH is the window.
     let initial_viewport = websem::InitialViewport::new(width as f32, height as f32);
     let retained = match (kind, admission) {
         (SourceKind::Svg, Admission::Strict) => {
-            websem::SvgFrameSource::from_standalone_svg(source, initial_viewport)
+            websem::SvgFrameSource::from_standalone_svg_with_fonts(source, initial_viewport, fonts)
         }
         (SourceKind::Svg, Admission::BestEffort) => {
-            websem::SvgFrameSource::from_standalone_svg_best_effort(source, initial_viewport)
+            websem::SvgFrameSource::from_standalone_svg_best_effort_with_fonts(
+                source,
+                initial_viewport,
+                fonts,
+            )
         }
+        // The inline-HTML entry declares no fonts yet: its `<text>` runs
+        // refuse by name, which is the hermetic default, not a silent drop.
         (SourceKind::Html, Admission::Strict) => {
             websem::SvgFrameSource::from_html_inline_svg(source)
         }
@@ -379,20 +427,20 @@ mod tests {
         assert_eq!(parse_size("auto"), None);
         assert_eq!(
             parse_render_options(&[]),
-            Ok((FramePolicy::Base, Admission::BestEffort)),
+            Ok((FramePolicy::Base, Admission::BestEffort, Vec::new())),
             "the unqualified default is best-effort Base"
         );
         assert_eq!(
             parse_render_options(&["--base".to_string()]),
-            Ok((FramePolicy::Base, Admission::BestEffort))
+            Ok((FramePolicy::Base, Admission::BestEffort, Vec::new()))
         );
         assert_eq!(
             parse_render_options(&["--strict".to_string()]),
-            Ok((FramePolicy::Base, Admission::Strict))
+            Ok((FramePolicy::Base, Admission::Strict, Vec::new()))
         );
         assert_eq!(
             parse_render_options(&["--best-effort".to_string()]),
-            Ok((FramePolicy::Base, Admission::BestEffort))
+            Ok((FramePolicy::Base, Admission::BestEffort, Vec::new()))
         );
         assert_eq!(
             parse_render_options(&[
@@ -402,7 +450,8 @@ mod tests {
             ]),
             Ok((
                 FramePolicy::Sample(SampleTime::from_nanoseconds(-1)),
-                Admission::Strict
+                Admission::Strict,
+                Vec::new()
             ))
         );
         assert_eq!(
@@ -413,7 +462,8 @@ mod tests {
             ]),
             Ok((
                 FramePolicy::Sample(SampleTime::from_nanoseconds(7)),
-                Admission::Strict
+                Admission::Strict,
+                Vec::new()
             )),
             "flag order is free"
         );
@@ -423,6 +473,73 @@ mod tests {
         );
         assert!(parse_render_options(&["--time-ns".to_string()]).is_err());
         assert!(parse_render_options(&["--time-ns".to_string(), "1.5".to_string()]).is_err());
+    }
+
+    /// The text slice is reachable from the product surface: a declared,
+    /// verified font makes a `<text>` run render, and the render is exactly
+    /// the Chromium oracle the text suite baked. Without the declaration
+    /// the same document refuses by name — the hermetic default, visible at
+    /// the CLI boundary rather than only inside the compiler.
+    #[test]
+    fn declared_fonts_render_text_and_an_undeclared_one_refuses() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let source =
+            std::fs::read_to_string(root.join("fixtures/web-first/text/svg-text-em-box.svg"))
+                .expect("read the text cell");
+
+        // No declaration: the run names the family it cannot resolve, and
+        // best-effort renders the rest of the document rather than guessing.
+        let (_, degradations) = render_source_to_png(
+            &source,
+            SourceKind::Svg,
+            100,
+            100,
+            FramePolicy::Base,
+            Admission::BestEffort,
+            textlayout::Environment::default(),
+        )
+        .expect("best-effort renders the admitted subset");
+        assert!(
+            degradations
+                .iter()
+                .any(|d| d.reason().contains("not in the declared environment")),
+            "an undeclared family is a named hole, never an ambient face"
+        );
+
+        // Declared and verified: the run renders, byte-identical to the
+        // committed Chromium oracle for the same cell.
+        let font = root.join("fixtures/web-first/fonts/ahem.ttf");
+        let declaration = fonts::parse_declaration(&format!(
+            "Ahem={}@sha256:b719ecb31c5b21fc573c03f6421c74ac63c271a5a3ff841e34f9705fb94b8448",
+            font.display()
+        ))
+        .expect("a well-formed declaration");
+        let environment = fonts::load_environment(&[declaration]).expect("the pinned bytes verify");
+        let (png, degradations) = render_source_to_png(
+            &source,
+            SourceKind::Svg,
+            100,
+            100,
+            FramePolicy::Base,
+            Admission::Strict,
+            environment,
+        )
+        .expect("a declared font resolves the run under --strict");
+        assert!(
+            degradations.is_empty(),
+            "nothing is degraded once the font is declared"
+        );
+
+        let raster = decode_png(&png).expect("decode the text render");
+        let oracle = decode_png(
+            &std::fs::read(root.join("fixtures/web-first/text/chromium/svg-text-em-box.png"))
+                .expect("read the committed oracle"),
+        )
+        .expect("decode the oracle");
+        assert_eq!(
+            raster.pixels, oracle.pixels,
+            "the host's text render is the Chromium oracle, byte for byte"
+        );
     }
 
     /// The strict admission keeps the refusal harness: inputs the retired
@@ -465,6 +582,7 @@ mod tests {
                 size.1,
                 FramePolicy::Base,
                 Admission::Strict,
+                textlayout::Environment::default(),
             )
             .expect_err("beyond-slice input must refuse under --strict, not render");
             assert!(
@@ -502,6 +620,7 @@ mod tests {
             400,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("best-effort renders the admitted subset");
         let raster = decode_png(&png).expect("decode PNG");
@@ -558,6 +677,7 @@ mod tests {
             64,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("best-effort renders the admitted circle");
         let raster = decode_png(&png).expect("decode PNG");
@@ -578,6 +698,7 @@ mod tests {
             64,
             FramePolicy::Base,
             Admission::Strict,
+            textlayout::Environment::default(),
         )
         .expect("strict admits the circle too");
         assert_eq!(png, strict_png, "admissions are byte-identical");
@@ -595,6 +716,7 @@ mod tests {
             64,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("best-effort renders the admitted path");
         let raster = decode_png(&png).expect("decode PNG");
@@ -615,6 +737,7 @@ mod tests {
             64,
             FramePolicy::Base,
             Admission::Strict,
+            textlayout::Environment::default(),
         )
         .expect("strict admits the path too");
         assert_eq!(png, strict_png, "admissions are byte-identical");
@@ -632,6 +755,7 @@ mod tests {
             64,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("best-effort renders the admitted polygon");
         let raster = decode_png(&png).expect("decode PNG");
@@ -652,6 +776,7 @@ mod tests {
             64,
             FramePolicy::Base,
             Admission::Strict,
+            textlayout::Environment::default(),
         )
         .expect("strict admits the polygon too");
         assert_eq!(png, strict_png, "admissions are byte-identical");
@@ -674,6 +799,7 @@ mod tests {
                 48,
                 FramePolicy::Base,
                 admission,
+                textlayout::Environment::default(),
             )
             .expect_err("root sizing is document-level in both admissions");
             assert!(
@@ -700,6 +826,7 @@ mod tests {
             32,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("viewBox-only renders by default");
         assert!(
@@ -726,6 +853,7 @@ mod tests {
             32,
             FramePolicy::Base,
             Admission::Strict,
+            textlayout::Environment::default(),
         )
         .expect("strict admits the same document");
         assert_eq!(png, strict_png, "admissions agree byte-for-byte");
@@ -738,6 +866,7 @@ mod tests {
             128,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("the raster is the initial viewport");
         let raster = decode_png(&large).expect("decode PNG");
@@ -771,6 +900,7 @@ mod tests {
             600,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("the first inline SVG is the admitted rect");
         assert!(
@@ -785,6 +915,7 @@ mod tests {
             600,
             FramePolicy::Base,
             Admission::Strict,
+            textlayout::Environment::default(),
         )
         .expect("repeat render (strict admission)");
         assert_eq!(first, second, "encoded determinism across admissions");
@@ -838,6 +969,7 @@ mod tests {
                 size.1,
                 FramePolicy::Base,
                 Admission::BestEffort,
+                textlayout::Environment::default(),
             )
             .unwrap_or_else(|error| panic!("render {relative}: {error}"));
             assert!(
@@ -851,6 +983,7 @@ mod tests {
                 size.1,
                 FramePolicy::Base,
                 Admission::Strict,
+                textlayout::Environment::default(),
             )
             .unwrap_or_else(|error| panic!("repeat {relative}: {error}"));
             assert_eq!(first, second, "{relative} byte-identical across admissions");
@@ -907,15 +1040,23 @@ mod tests {
                 32,
                 policy,
                 Admission::BestEffort,
+                textlayout::Environment::default(),
             )
             .unwrap_or_else(|error| panic!("render {policy:?}: {error}"));
             assert!(
                 degradations.is_empty(),
                 "the admitted x animation degrades nothing"
             );
-            let (second, _) =
-                render_source_to_png(&source, SourceKind::Svg, 64, 32, policy, Admission::Strict)
-                    .unwrap_or_else(|error| panic!("repeat {policy:?}: {error}"));
+            let (second, _) = render_source_to_png(
+                &source,
+                SourceKind::Svg,
+                64,
+                32,
+                policy,
+                Admission::Strict,
+                textlayout::Environment::default(),
+            )
+            .unwrap_or_else(|error| panic!("repeat {policy:?}: {error}"));
             assert_eq!(first, second, "{policy:?} byte-identical across admissions");
             let raster = decode_png(&first).expect("decode exact-time PNG");
             let expected = decode_png(
@@ -967,15 +1108,23 @@ mod tests {
                 96,
                 policy,
                 Admission::BestEffort,
+                textlayout::Environment::default(),
             )
             .unwrap_or_else(|error| panic!("render {policy:?}: {error}"));
             assert!(
                 degradations.is_empty(),
                 "the cub scene is fully admitted; {policy:?} declares {degradations:?}"
             );
-            let (strict, _) =
-                render_source_to_png(source, SourceKind::Svg, 96, 96, policy, Admission::Strict)
-                    .unwrap_or_else(|error| panic!("strict render {policy:?}: {error}"));
+            let (strict, _) = render_source_to_png(
+                source,
+                SourceKind::Svg,
+                96,
+                96,
+                policy,
+                Admission::Strict,
+                textlayout::Environment::default(),
+            )
+            .unwrap_or_else(|error| panic!("strict render {policy:?}: {error}"));
             assert_eq!(
                 best_effort, strict,
                 "{policy:?} byte-identical across admissions"
@@ -1105,6 +1254,7 @@ mod tests {
             64,
             FramePolicy::Sample(SampleTime::ZERO),
             Admission::Strict,
+            textlayout::Environment::default(),
         )
         .expect_err("inline-HTML sampling is not admitted under --strict");
         assert!(
@@ -1119,6 +1269,7 @@ mod tests {
             64,
             FramePolicy::Sample(SampleTime::ZERO),
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("the default admission samples as the Base view");
         assert_eq!(degradations.len(), 1, "declared exactly once");
@@ -1134,6 +1285,7 @@ mod tests {
             64,
             FramePolicy::Base,
             Admission::BestEffort,
+            textlayout::Environment::default(),
         )
         .expect("Base render");
         assert!(
@@ -1150,6 +1302,7 @@ mod tests {
                 32,
                 FramePolicy::Base,
                 admission,
+                textlayout::Environment::default(),
             )
             .expect_err("a document with no inline SVG refuses at construction");
             assert!(


### PR DESCRIPTION
Text was compilable but **unreachable from the product surface**. [#71](https://github.com/gridaco/nothing/pull/71) admitted `<text>`, but the CLI had no way to declare a font, so every run refused — the feature shipped behind a door with no handle. This adds the handle, under the hermetic rule the method ratified in [#68](https://github.com/gridaco/nothing/pull/68).

```sh
n0 fixtures/web-first/text/svg-text-em-box.svg out.png 100x100 \
  --font Ahem=fixtures/web-first/fonts/ahem.ttf@sha256:b719ecb3…94b8448
```

## The digest is executable

A family name is not a font identity — the same name resolves to different bytes on different machines — so a declaration carries the digest of the bytes it means, and the host **verifies before a frame exists**. Three behaviors, all exercised against the real binary:

| Invocation | Result |
|---|---|
| declared + verified | renders; byte-identical to the committed Chromium oracle |
| no declaration | `degraded: skipped svg/text[1]: … font family "Ahem" is not in the declared environment` |
| wrong digest | `error: … is not the declared identity: expected sha256 0000…, read b719ecb3…` — refuses before any pixel |

No system fallback, no ambient face, no machine-local pixel anywhere on this path.

## The end-to-end law

`declared_fonts_render_text_and_an_undeclared_one_refuses` renders the text cell **through the host** and asserts it equals `fixtures/web-first/text/chromium/svg-text-em-box.png` byte for byte — the same cell the compiler gate uses, now proven through the surface it actually ships behind. The parse and verification laws cover the grammar's edges: a path containing `=` and `@` still parses (only the first `=` ends the family, only the last `@sha256:` ends the path), a missing or malformed digest refuses with the reason, and the pinned gate font verifies while a wrong digest does not.

## Statement of record

[`crates/n0_cli/README.md`](https://github.com/gridaco/nothing/blob/text-1c-cli-fonts/crates/n0_cli/README.md) gains the text slice — the environment rule, the v0 profile, what places a run, the numeric domain and *why* it is where the gate holds, and every named refusal (the CSS spelling of `text-anchor`, a generic family, `<tspan>`, stroke on text, colour faces, the inline-HTML entry which declares no fonts). That file is the one statement of record for the admitted slice, so this closes the gap #71 left in it.

Full workspace green, fmt and clippy clean, lock unchanged (`sha2` was already in the graph).

With this, text is complete end to end and the arc's remaining item is **text-2 — the D-M deciding spike**.