### PR TITLE
The loop's toolbox: one capture posture, pinned; the ritual, saved

### DIFF
--- a/.agents/workflows/verify-rung.js
+++ b/.agents/workflows/verify-rung.js
@@ -1,0 +1,84 @@
+// The checklist loop's pre-landing verification ritual, as a saved workflow.
+//
+// Invoke with args = { brief: "<the rung brief>" } — a self-contained account
+// of the staged (uncommitted) rung: what changed and why, the probe verdicts
+// with the probe script path and its exact rerun command, which checklist rows
+// tick and on what evidence, and any claim the judges should try to refute.
+// The judges run `git status`/`git diff` themselves; the brief is the rung's
+// testimony, not a substitute for the tree.
+//
+// Two judges, the shape proven on the stroke-join and linecap rungs:
+// a tick/law auditor and an independent reproducer. Both default to
+// skepticism; a finding without evidence is not a finding.
+
+export const meta = {
+  name: 'verify-rung',
+  description: 'Adversarially verify a staged checklist-loop rung before landing',
+  whenToUse:
+    'After a rung is fully staged in the working tree and green locally; pass args={brief}.',
+  phases: [{ title: 'Verify' }],
+}
+
+const VERDICT = {
+  type: 'object',
+  required: ['verdict', 'findings'],
+  properties: {
+    verdict: { type: 'string', enum: ['pass', 'must_fix', 'should_fix'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'claim', 'evidence'],
+        properties: {
+          severity: { type: 'string', enum: ['must_fix', 'should_fix', 'note'] },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// Accept args as {brief}, as a JSON-encoded string of that shape, or as the
+// brief text itself — harnesses differ in how they deliver args.
+let input = args
+if (typeof input === 'string') {
+  try {
+    const parsed = JSON.parse(input)
+    input = typeof parsed === 'string' ? { brief: parsed } : parsed
+  } catch {
+    input = { brief: input }
+  }
+}
+const brief = input && input.brief ? String(input.brief) : null
+if (!brief) throw new Error('verify-rung requires args = { brief: string } (or the brief text itself)')
+
+const COMMON = `You are verifying a staged, uncommitted rung of the Web checklist loop in this repository (your working directory). Run \`git status --short\` and \`git diff\` to see the change; new files may be untracked under fixtures/web-first/.
+
+THE RUNG BRIEF (the session's testimony — verify it, do not trust it):
+${brief}
+
+Standing law you enforce (read the sources, not this summary): the strict tick rule and its named precedents live in the header of docs/wg/consolidation/web-checklist.md; the corpus disciplines (never-overwrite bake, measured-vs-celled markers, no tolerance block without a measured bound) live in fixtures/web-first/README.md; no conformance score or ratio may appear anywhere (FLIP law); probes are scratch and must not be committed; statements of record are linked, never restated.
+
+Return structured findings. Default to skepticism: a finding you cannot evidence is not a finding, but a real gap must be named must_fix.`
+
+phase('Verify')
+const results = await parallel([
+  () =>
+    agent(
+      `${COMMON}
+
+You are the TICK + LAW AUDITOR. (1) For every checklist row the diff ticks: verify its FULL listed grammar (fetch the section's cited spec index if needed) now has Chromium-gated committed coverage, judged under the header's rules and precedents — and that no OTHER row is owed a tick or an untick by this change. (2) Audit every prose claim in the diff (README rows, statements of record, code comments) against committed artifacts: probe-only facts must be marked measured-not-celled; a claim of cell coverage that no cell backs is a must_fix. (3) Verify the checklist diff contains exactly the claimed tick flips and nothing else, and that no score, ratio, or machine-specific path appears anywhere in the diff.`,
+      { label: 'tick-law-audit', phase: 'Verify', schema: VERDICT },
+    ),
+  () =>
+    agent(
+      `${COMMON}
+
+You are the REPRO VERIFIER. (1) Re-run the probe script named in the brief with its stated command and confirm every claimed pair verdict. (2) Run the engine gate (just gate in fixtures/web-first/, or cargo test -p websem --test reftest_oracle) and confirm it passes; confirm from the test source what bar the new cells actually passed (byte-exact unless a tolerance block declares a measured bound). (3) Verify manifest hygiene: fixtures on disk match their entries, primitives.json stayed sorted and additions-only, oracle-bake.json gained exactly the new records with correct hashes. (4) Run the STATUS freshness gate (just status) and confirm no further diff. (5) Spot-check the fixtures' bytes are minimal and their geometry actually discriminates the measured claims.`,
+      { label: 'repro', phase: 'Verify', schema: VERDICT },
+    ),
+])
+
+const [audit, repro] = results
+return { audit, repro }

--- a/.claude/workflows
+++ b/.claude/workflows
@@ -1,0 +1,1 @@
+../.agents/workflows

--- a/crates/websem/tests/reftest_oracle.rs
+++ b/crates/websem/tests/reftest_oracle.rs
@@ -109,6 +109,7 @@ impl Boundary {
 struct BakeManifest {
     schema_version: u32,
     bake_script_sha256: String,
+    capture_module_sha256: String,
     suite: String,
     suite_sha256: String,
     fixtures: Vec<BakeRecord>,
@@ -250,6 +251,11 @@ fn primitive_oracle_provenance_is_current() {
         manifest.bake_script_sha256,
         sha256_file(&root.join("bake_chromium.ts")),
         "Chromium baker changed without refreshing provenance"
+    );
+    assert_eq!(
+        manifest.capture_module_sha256,
+        sha256_file(&root.join("chromium_capture.ts")),
+        "Chromium capture posture changed without refreshing provenance"
     );
     assert_eq!(manifest.fixtures.len(), suite.fixtures.len());
 

--- a/fixtures/web-first/README.md
+++ b/fixtures/web-first/README.md
@@ -211,3 +211,23 @@ HTML ancestor — through the same Stylo cascade, not a second matcher.
 They are about the crossing, not about paint breadth: cascaded `fill` from a
 presentation hint and from an SVG-namespace stylesheet has its own cells
 elsewhere in this table.
+
+## Tooling
+
+The loop's per-rung commands live in this directory's `justfile` (`just -l`):
+`bake` (create missing oracles, verify every existing one pixel-for-pixel),
+`gate` (the engine reftest over every cell — byte-exact except the declared
+tolerance rows), `status` (regenerate
+[STATUS.md](./STATUS.md)), `add <id> <svg>` (register a fixture with a sorted
+manifest entry, refusing overwrites), and `probe <script>` (run a scratch
+probe).
+
+The Chromium capture posture lives in **one module**,
+[`chromium_capture.ts`](./chromium_capture.ts), imported by both the baker and
+[`probe_harness.ts`](./probe_harness.ts) — so a probe measures under exactly
+the conditions the cells bake under, and the posture cannot silently drift:
+`oracle-bake.json` records the module's sha256 and the Rust gate refuses a
+stale one. Probe *matrices* stay scratch and are never committed; a probe is a
+question asked once, and what it proves lands as cells and README rows, not as
+a shadow corpus. The pre-landing verification ritual is the saved
+`verify-rung` workflow (`.agents/workflows/verify-rung.js`).

--- a/fixtures/web-first/add_cell.py
+++ b/fixtures/web-first/add_cell.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Add a cell to the Web-first primitive suite.
+
+Writes the fixture source (refusing to overwrite) and inserts its
+`primitives.json` entry in sorted order (refusing a duplicate id or source).
+The oracle is NOT created here — run `just bake` after, which creates the
+missing oracle and verifies every existing one byte-for-byte (the
+never-overwrite law lives in the baker, `bake_chromium.ts`).
+
+Usage:
+    python3 add_cell.py <id> --svg <path|-> [--width N] [--height N]
+
+The id becomes `<id>.svg` / `chromium/<id>.png`. `--svg -` reads the source
+from stdin. Entries default to the 64x64 `standalone-svg` shape every recent
+cell uses; pass --width/--height for other dims. An `html-inline-svg` cell is
+rare enough to author by hand.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DIR = Path(__file__).resolve().parent
+MANIFEST = DIR / "primitives.json"
+ID_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("id", help="cell id, kebab-case (e.g. svg-stroke-cap-css-butt)")
+    parser.add_argument("--svg", required=True, help="path to the SVG source, or - for stdin")
+    parser.add_argument("--width", type=int, default=64)
+    parser.add_argument("--height", type=int, default=64)
+    args = parser.parse_args()
+
+    if not ID_PATTERN.match(args.id):
+        sys.exit(f"refused: id {args.id!r} is not kebab-case")
+
+    body = sys.stdin.read() if args.svg == "-" else Path(args.svg).read_text()
+    if "<svg" not in body:
+        sys.exit("refused: source has no <svg> element")
+    if not body.endswith("\n"):
+        body += "\n"
+
+    fixture_path = DIR / f"{args.id}.svg"
+    if fixture_path.exists():
+        sys.exit(f"refused: {fixture_path.name} already exists")
+
+    manifest = json.loads(MANIFEST.read_text())
+    fixtures = manifest["fixtures"]
+    taken = {f["id"] for f in fixtures} | {f["source"] for f in fixtures}
+    if args.id in taken or f"{args.id}.svg" in taken:
+        sys.exit(f"refused: {args.id!r} already enumerated in primitives.json")
+
+    fixtures.append(
+        {
+            "id": args.id,
+            "source": f"{args.id}.svg",
+            "entry": "standalone-svg",
+            "oracle": f"chromium/{args.id}.png",
+            "width": args.width,
+            "height": args.height,
+        }
+    )
+    fixtures.sort(key=lambda f: f["id"])
+
+    fixture_path.write_text(body)
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"added {args.id} ({args.width}x{args.height}); run `just bake` to create its oracle")
+
+
+if __name__ == "__main__":
+    main()

--- a/fixtures/web-first/bake_chromium.ts
+++ b/fixtures/web-first/bake_chromium.ts
@@ -21,8 +21,14 @@ import { dirname, join } from "node:path";
 import { exit } from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { chromium, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { PNG } from "pngjs";
+
+import {
+  captureFirstSvg,
+  deterministicContext,
+  launchDeterministicChromium,
+} from "./chromium_capture";
 
 type Entry = "standalone-svg" | "html-inline-svg";
 
@@ -73,29 +79,15 @@ function assertSamePixels(existing: Buffer, fresh: Buffer, id: string): void {
 }
 
 async function captureSvg(page: Page, fixture: Primitive, source: Buffer): Promise<Buffer> {
-  // standalone-svg: the window IS the initial viewport (SVG2 §8.2) the
-  // fixture's declared dims stand for — a missing root width/height is
-  // `auto` and resolves to 100% of it, so viewBox-only fixtures bake at
-  // exactly their declared size. html-inline-svg keeps the fixed 1280x720
-  // posture: that entry has no initial-viewport semantics yet.
-  if (fixture.entry === "standalone-svg") {
-    await page.setViewportSize({ width: fixture.width, height: fixture.height });
-  }
-  const media = fixture.entry === "standalone-svg" ? "image/svg+xml" : "text/html";
-  const dataUrl = `data:${media};base64,${source.toString("base64")}`;
-  await page.goto(dataUrl, { waitUntil: "load" });
-
-  const svg = page.locator("svg").first();
-  if ((await svg.count()) !== 1) {
-    throw new Error(`${fixture.id}: expected a first <svg> element`);
-  }
-  const box = await svg.boundingBox();
-  if (!box || box.width !== fixture.width || box.height !== fixture.height) {
-    throw new Error(
-      `${fixture.id}: unexpected SVG box ${JSON.stringify(box)}; expected ${fixture.width}x${fixture.height}`,
-    );
-  }
-  return svg.screenshot({ omitBackground: true, type: "png" });
+  // The posture lives in `chromium_capture.ts` — the one module probes share
+  // — and its hash is recorded in the manifest below.
+  return captureFirstSvg(page, {
+    media: fixture.entry === "standalone-svg" ? "image/svg+xml" : "text/html",
+    source,
+    width: fixture.width,
+    height: fixture.height,
+    label: fixture.id,
+  });
 }
 
 async function main(): Promise<void> {
@@ -106,19 +98,10 @@ async function main(): Promise<void> {
   }
 
   const scriptBytes = await readFile(SCRIPT_PATH);
-  const browser = await chromium.launch({
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
+  const captureBytes = await readFile(join(DIR, "chromium_capture.ts"));
+  const browser = await launchDeterministicChromium();
   const browserVersion = browser.version();
-  const context = await browser.newContext({
-    javaScriptEnabled: false,
-    viewport: { width: 1280, height: 720 },
-    deviceScaleFactor: 1,
-    colorScheme: "light",
-    locale: "en-US",
-    timezoneId: "UTC",
-  });
-  await context.route("**/*", (route) => route.abort());
+  const context = await deterministicContext(browser);
 
   const records: Array<Record<string, unknown>> = [];
   for (const fixture of suite.fixtures) {
@@ -164,6 +147,7 @@ async function main(): Promise<void> {
     kind: "chromium-primitive-suite",
     browser_version: browserVersion,
     bake_script_sha256: sha256(scriptBytes),
+    capture_module_sha256: sha256(captureBytes),
     suite: "primitives.json",
     suite_sha256: sha256(suiteBytes),
     capture: {

--- a/fixtures/web-first/chromium_capture.ts
+++ b/fixtures/web-first/chromium_capture.ts
@@ -1,0 +1,77 @@
+/**
+ * The one Chromium capture posture for the Web-first primitive suite.
+ *
+ * Both consumers import this module — `bake_chromium.ts` (the committed
+ * oracles) and `probe_harness.ts` (scratch probes) — so a probe measures
+ * under exactly the conditions the cells are baked under, instead of a
+ * hand-copied posture that can drift. The posture is provenance:
+ * `oracle-bake.json` records this file's sha256 alongside the baker's, and
+ * `crates/websem/tests/reftest_oracle.rs` refuses a suite whose recorded
+ * posture hash is stale.
+ */
+
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+
+export async function launchDeterministicChromium(): Promise<Browser> {
+  return chromium.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
+}
+
+export async function deterministicContext(
+  browser: Browser,
+): Promise<BrowserContext> {
+  const context = await browser.newContext({
+    javaScriptEnabled: false,
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 1,
+    colorScheme: "light",
+    locale: "en-US",
+    timezoneId: "UTC",
+  });
+  await context.route("**/*", (route) => route.abort());
+  return context;
+}
+
+export interface SvgCapture {
+  media: "image/svg+xml" | "text/html";
+  source: Buffer;
+  width: number;
+  height: number;
+  /** Prefixes error messages, e.g. a fixture or probe id. */
+  label: string;
+}
+
+/**
+ * Capture the first `<svg>` element of the source as PNG bytes.
+ *
+ * standalone-svg (`image/svg+xml`): the window IS the initial viewport
+ * (SVG2 §8.2) the declared dims stand for — a missing root width/height is
+ * `auto` and resolves to 100% of it. html-inline-svg keeps the context's
+ * fixed 1280x720 posture: that entry has no initial-viewport semantics yet.
+ */
+export async function captureFirstSvg(
+  page: Page,
+  capture: SvgCapture,
+): Promise<Buffer> {
+  if (capture.media === "image/svg+xml") {
+    await page.setViewportSize({ width: capture.width, height: capture.height });
+  }
+  const dataUrl = `data:${capture.media};base64,${capture.source.toString("base64")}`;
+  await page.goto(dataUrl, { waitUntil: "load" });
+
+  const svg = page.locator("svg").first();
+  if ((await svg.count()) !== 1) {
+    throw new Error(`${capture.label}: expected a first <svg> element`);
+  }
+  const box = await svg.boundingBox();
+  if (!box || box.width !== capture.width || box.height !== capture.height) {
+    throw new Error(
+      `${capture.label}: unexpected SVG box ${JSON.stringify(box)}; expected ${capture.width}x${capture.height}`,
+    );
+  }
+  return svg.screenshot({ omitBackground: true, type: "png" });
+}

--- a/fixtures/web-first/justfile
+++ b/fixtures/web-first/justfile
@@ -1,0 +1,32 @@
+# The Web-first suite toolbox — the checklist loop's per-rung commands.
+# `just -l` lists recipes; see README.md § Tooling for the loop itself.
+
+set shell := ["bash", "-cu"]
+
+# Node env for the Playwright-side scripts (the pinned Chromium lives in
+# packages/grida-reftest's workspace; that package's scoring machinery is
+# legacy-engine estate the loop never touches). nvm is sourced only where it
+# exists — a machine with pnpm already on PATH needs nothing.
+node_env := 'export NVM_DIR="$HOME/.nvm"; { [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"; } || true;'
+cargo_env := 'export PATH="$HOME/.cargo/bin:$PATH";'
+
+# Bake/verify all committed oracles: creates missing, refuses drift.
+bake:
+    {{node_env}} pnpm -C {{justfile_directory()}}/../../packages/grida-reftest exec tsx {{justfile_directory()}}/bake_chromium.ts
+
+# Run a scratch probe script (author it against probe_harness.ts; never commit it).
+probe file:
+    {{node_env}} pnpm -C {{justfile_directory()}}/../../packages/grida-reftest exec tsx {{file}}
+
+# The engine gate over every cell (websem → rframe → n0) — byte-exact
+# except the rows whose declared tolerance blocks carry measured bounds.
+gate:
+    {{cargo_env}} cargo test -p websem --test reftest_oracle
+
+# Regenerate STATUS.md and its freshness gate.
+status:
+    {{cargo_env}} UPDATE_CAPABILITY_STATUS=1 cargo test -p websem --test capability_status
+
+# Register a new 64x64 standalone-svg cell (fixture + sorted manifest entry).
+add id svg:
+    python3 {{justfile_directory()}}/add_cell.py {{id}} --svg {{svg}}

--- a/fixtures/web-first/oracle-bake.json
+++ b/fixtures/web-first/oracle-bake.json
@@ -2,7 +2,8 @@
   "schema_version": 1,
   "kind": "chromium-primitive-suite",
   "browser_version": "149.0.7827.55",
-  "bake_script_sha256": "373cbea5476067163b6f8ebfc90eb49b7f49ae7758be0916d34db906399e1d5e",
+  "bake_script_sha256": "2bdb5f933d072a1e87c9a675c3342fcf506c0955c0f5c26e2988f4e8fa37c4f2",
+  "capture_module_sha256": "15ba5c3156f3ed0bfd0f32b6ad773e1d228c0f678396db08c8de1d972cf5bced",
   "suite": "primitives.json",
   "suite_sha256": "e792f6de71eb311a8270f63d09d46dfdad3de0b0aef447a0514643c280f510b4",
   "capture": {

--- a/fixtures/web-first/probe_harness.ts
+++ b/fixtures/web-first/probe_harness.ts
@@ -1,0 +1,117 @@
+/**
+ * Probe harness — committed so scratch probes inherit the bake's exact
+ * capture posture (`chromium_capture.ts`) instead of copy-pasting it.
+ *
+ * Only mechanics live here. The probe MATRICES stay scratch and are never
+ * committed: a probe is a question asked once; what it proves lands as
+ * cells, README rows, and records — not as a shadow corpus.
+ *
+ * A scratch probe reduces to data:
+ *
+ * ```ts
+ * import { runProbeMatrix } from "<repo>/fixtures/web-first/probe_harness";
+ * runProbeMatrix({
+ *   probes: { "case-a": "<svg …>…</svg>", "case-b": "<svg …>…</svg>" },
+ *   pairs: [["case-a", "case-b", "what identity/difference would mean"]],
+ *   outDir: "<scratch dir>",
+ * }).catch((e) => { console.error(e); process.exit(1); });
+ * ```
+ *
+ * Run via `just probe <script>` (see the justfile in this directory).
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { PNG } from "pngjs";
+
+import {
+  captureFirstSvg,
+  deterministicContext,
+  launchDeterministicChromium,
+} from "./chromium_capture";
+
+export interface ProbeComparison {
+  identical: boolean;
+  diffPixels: number;
+  maxDelta: number;
+}
+
+/** Byte compare first; on mismatch, count differing pixels and the largest
+ * per-channel delta over the decoded RGBA. */
+export function comparePngs(a: Buffer, b: Buffer): ProbeComparison {
+  if (a.equals(b)) return { identical: true, diffPixels: 0, maxDelta: 0 };
+  const pa = PNG.sync.read(a);
+  const pb = PNG.sync.read(b);
+  let diffPixels = 0;
+  let maxDelta = 0;
+  for (let i = 0; i < pa.data.length; i += 4) {
+    let pixelDiffers = false;
+    for (let c = 0; c < 4; c += 1) {
+      const d = Math.abs(pa.data[i + c] - pb.data[i + c]);
+      if (d > 0) pixelDiffers = true;
+      if (d > maxDelta) maxDelta = d;
+    }
+    if (pixelDiffers) diffPixels += 1;
+  }
+  return { identical: false, diffPixels, maxDelta };
+}
+
+export interface ProbeMatrix {
+  /** id → standalone SVG source. */
+  probes: Record<string, string>;
+  /** [left id, right id, what identity/difference would mean]. */
+  pairs: Array<[string, string, string]>;
+  /** Where captures are written for eyeballing (scratch space). */
+  outDir: string;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Capture every probe twice (byte-determinism asserted, as the bake does),
+ * write the PNGs to `outDir`, and print one verdict line per pair:
+ * `IDENTICAL` or `DIFFER (Npx, maxΔD)`.
+ */
+export async function runProbeMatrix(matrix: ProbeMatrix): Promise<void> {
+  const width = matrix.width ?? 64;
+  const height = matrix.height ?? 64;
+  await mkdir(matrix.outDir, { recursive: true });
+
+  const browser = await launchDeterministicChromium();
+  console.log(`chromium ${browser.version()}`);
+  const context = await deterministicContext(browser);
+
+  const shots = new Map<string, Buffer>();
+  for (const [id, svg] of Object.entries(matrix.probes)) {
+    const page = await context.newPage();
+    const capture = {
+      media: "image/svg+xml" as const,
+      source: Buffer.from(svg),
+      width,
+      height,
+      label: id,
+    };
+    const first = await captureFirstSvg(page, capture);
+    const second = await captureFirstSvg(page, capture);
+    await page.close();
+    if (!first.equals(second)) throw new Error(`${id}: not byte-deterministic`);
+    shots.set(id, first);
+    await writeFile(join(matrix.outDir, `${id}.png`), first);
+  }
+
+  console.log("\npair verdicts:");
+  for (const [left, right, note] of matrix.pairs) {
+    const a = shots.get(left);
+    const b = shots.get(right);
+    if (!a || !b) throw new Error(`missing shot ${left} / ${right}`);
+    const r = comparePngs(a, b);
+    const verdict = r.identical
+      ? "IDENTICAL"
+      : `DIFFER (${r.diffPixels}px, maxΔ${r.maxDelta})`;
+    console.log(`${left} vs ${right}: ${verdict}  — ${note}`);
+  }
+
+  await context.close();
+  await browser.close();
+}


### PR DESCRIPTION
The desk-clean between checklist-loop iterations — **no cells, no ticks, zero engine code** (one provenance assert is the only Rust change).

## The hazard this closes

Probes copied the bake's Chromium capture posture by hand ([#77](https://github.com/gridaco/nothing/pull/77), [#78](https://github.com/gridaco/nothing/pull/78) both did). A posture change would silently diverge what a probe *measures* from what the cells *bake under* — a measurement taken under the wrong conditions is the believed-wrong-answer class the repo laws exist to prevent. Now:

- **`chromium_capture.ts`** is the one posture, imported by both `bake_chromium.ts` and the new **`probe_harness.ts`** (scratch probes shrink to a data matrix).
- **The posture is provenance**: `oracle-bake.json` records `capture_module_sha256` and the Rust gate refuses a stale one.
- **Byte-fidelity proof**: the rebake through the refactored baker verified all 206 committed oracles unchanged; the repro judge confirmed the regenerated manifest is byte-identical apart from the two script hashes.

## The friction removals

- **`fixtures/web-first/justfile`** — `bake` / `gate` / `status` / `probe <script>` / `add <id> <svg>`, carrying the env incantations (nvm sourced only where it exists, per audit).
- **`add_cell.py`** — fixture + sorted manifest entry with refusal built in (overwrite, duplicate id, non-kebab name, non-SVG body — all exercised).
- **`verify-rung`** (`.agents/workflows/`, `.claude/workflows` symlink per the skills convention) — the pre-landing adversarial ritual as a saved workflow taking the rung brief as args. Its first execution verified this very change, and its first launch attempt caught its own args-delivery bug — which is what the ritual is for.

Probe *matrices* stay scratch by law; only mechanics are committed. README gains a Tooling section stating all of this.

Verification: two judges via the saved workflow — repro **pass** (independent rebake no-op, probe re-run, hash triangulation, add_cell refusals), audit one should_fix (the nvm guard) + wording notes, all applied.