### PR TITLE
websem: gate real-font SVG text geometry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6540,6 +6540,7 @@ dependencies = [
  "math2",
  "n0",
  "rframe",
+ "rustybuzz",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/n0_cli/README.md
+++ b/crates/n0_cli/README.md
@@ -35,6 +35,13 @@ cargo run -p n0_cli --bin n0 -- \
   fixtures/web-first/text/svg-text-em-box.svg /tmp/text.png 100x100 \
   --font Ahem=fixtures/web-first/fonts/ahem.ttf@sha256:b719ecb31c5b21fc573c03f6421c74ac63c271a5a3ff841e34f9705fb94b8448
 
+# real-font Rung B: artifact geometry is graded exactly before rasterization;
+# this render makes no Chromium real-font pixel claim
+cargo run -p n0_cli --bin n0 -- \
+  fixtures/web-first/text/geometry/svg-text-allerta-geometry.svg \
+  /tmp/text-allerta.png 1200x500 \
+  --font Allerta=fixtures/fonts/Allerta/Allerta-Regular.ttf@sha256:16d6915227c7560725c037c9c93163cba5367c3ef4cf2ec12bf40b9eb2984a6b
+
 # dev harness: refuse on the first beyond-slice construct instead of
 # rendering best-effort with declared degradations (the default)
 cargo run -p n0_cli --bin n0 -- \
@@ -558,8 +565,9 @@ cargo run -p n0_cli --bin n0 -- \
   drop-shadow, 27 color-matrix, 34 component-transfer, 38 blend, 37 morphology,
   91 turbulence/displacement, 41 convolution-rung, and 71 diffuse-lighting
   cells. The complete primitive corpus contains 1,051 Chromium-baked cells plus
-  16 sampled frames; the dedicated exact text suite contains nine cells, and
-  the named refusal register has 206 rows. `feFlood`, `feComposite`,
+  16 sampled frames; the text estate contains nine exact Ahem pixel cells and
+  one exact-number Allerta artifact-geometry witness, and the named refusal
+  register has 207 rows. `feFlood`, `feComposite`,
   `feMerge`, `feMergeNode`, `feDropShadow`, `feColorMatrix`,
   `feComponentTransfer`, `feBlend`, `feMorphology`, `feConvolveMatrix`,
   `feDiffuseLighting`, `feDistantLight`, `fePointLight`, `feSpotLight`,
@@ -980,7 +988,23 @@ cargo run -p n0_cli --bin n0 -- \
   cancel exactly are admitted; any non-identity or fractional final mapping
   refuses. Chromium
   snaps everything else by a rasterizer-internal rule, and this refuses by
-  name instead of codifying it. What refuses by name: the CSS spelling of
+  name instead of codifying it. Real-font Rung B adds an independent
+  pre-raster geometry boundary. Chromium exposes each horizontal SVG
+  character cell after enclosing its start/end on a 1/64 CSS-pixel grid and
+  exposes vertical cells through integral fixed ascent/descent metrics. A run
+  is admitted only when every resolved glyph boundary already lies on that
+  grid and both metrics are already integral; the compiler never changes the
+  artifact to imitate the query. A pinned Allerta `Hxi` witness at 5120px
+  matches Chromium's total advance, per-character starts/ends/extents,
+  baseline, and anchor placement exactly. Glyph ids, clusters, units-per-em,
+  and outline bounds are checked separately against the same pinned font bytes
+  because browser text-query APIs do not expose those facts. The 1000px
+  control misses both query grids: strict refuses by stable
+  `Chromium SVG text query` name, while best effort skips and declares that
+  text node. Real-font
+  pixels are checked only for engine determinism and admission identity; no
+  Chromium raster claim or tolerance is made, and no text fact crosses
+  `rframe`. What refuses by name: the CSS spelling of
   `text-anchor` (Chromium consumes it from the cascade, the pinned Stylo
   build has no such longhand — a silent drop before the rung), inherited
   `text-anchor` presentation attributes, a generic

--- a/crates/websem/Cargo.toml
+++ b/crates/websem/Cargo.toml
@@ -57,6 +57,9 @@ skia-safe = { version = "=0.99.0", features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+# The rung-B geometry gate checks the recorded glyph ids directly against the
+# pinned face's cmap before comparing browser-visible geometry.
+rustybuzz = "=0.20.1"
 
 [lints]
 workspace = true

--- a/crates/websem/src/svg_text.rs
+++ b/crates/websem/src/svg_text.rs
@@ -9,7 +9,9 @@
 //! font identity crosses into `rframe`.
 
 use rframe::{FillRule, PathCommand, PathData};
-use textlayout::{AttributedText, Environment, OutlineSink, ResolveError, Style};
+use textlayout::{
+    AttributedText, Environment, OutlineSink, ResolveError, ResolvedTextLayout, Style,
+};
 
 /// SVG2 §11.1 `text-anchor`: where the resolved run sits relative to the
 /// element's authored position.
@@ -170,6 +172,43 @@ fn admit_numeric_domain(x: f32, y: f32, font_size: f32, start_x: f32) -> Result<
     Ok(())
 }
 
+/// Admit only resolved geometry that Chromium's SVG text-query projection
+/// leaves unchanged.
+///
+/// Blink carries horizontal character boundaries through a 1/64 fixed-point
+/// `LayoutUnit` and builds each queried cell by flooring its start and
+/// ceiling its end. It exposes vertical character cells through fixed
+/// integer ascent/descent metrics. If this artifact falls between either
+/// grid, the DOM geometry Chromium reports is not the artifact we would
+/// lower. That route refuses until a later oracle version deliberately owns
+/// the normalization; the patrol never changes a glyph position.
+fn admit_chromium_query_geometry(layout: &ResolvedTextLayout) -> Result<(), TextError> {
+    const QUERY_GRID: f32 = 64.0;
+    let on_query_grid = |value: f32| {
+        let scaled = value * QUERY_GRID;
+        value.is_finite() && scaled.is_finite() && scaled.fract() == 0.0
+    };
+    let integral = |value: f32| value.is_finite() && value.fract() == 0.0;
+
+    let metrics = layout.metrics();
+    if !integral(metrics.ascent) || !integral(metrics.descent) {
+        return Err(TextError::OutsideNumericDomain(format!(
+            "Chromium SVG text query metrics would round ascent/descent ({}, {}) to its integer fixed-metric grid",
+            metrics.ascent, metrics.descent
+        )));
+    }
+    for (index, glyph) in layout.glyphs().iter().enumerate() {
+        let end = glyph.x + glyph.advance;
+        if !on_query_grid(glyph.x) || !on_query_grid(end) {
+            return Err(TextError::OutsideNumericDomain(format!(
+                "glyph {index} boundaries ({}, {end}) do not lie on Chromium's 1/64 SVG text query grid",
+                glyph.x
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Resolve one `<text>` run and lower its glyphs to the resolved contract's
 /// path vocabulary, in the element's local space.
 ///
@@ -196,6 +235,7 @@ pub(crate) fn resolve_text_path(
 
     let start_x = anchor.start_x(x, layout.advance());
     admit_numeric_domain(x, y, font_size, start_x)?;
+    admit_chromium_query_geometry(&layout)?;
 
     let mut sink = PathSink {
         origin_x: start_x,

--- a/crates/websem/tests/capability_status.rs
+++ b/crates/websem/tests/capability_status.rs
@@ -14,6 +14,9 @@
 //! UPDATE_CAPABILITY_STATUS=1 cargo test -p websem --test capability_status
 //! ```
 
+#[path = "support/fixture_fonts.rs"]
+mod fixture_fonts;
+
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -147,10 +150,18 @@ fn generate() -> String {
     for id in &refusals {
         let source = fs::read_to_string(root.join("unsupported").join(format!("{id}.svg")))
             .unwrap_or_else(|error| panic!("{id}: read: {error}"));
-        let strict = SvgFrameSource::from_standalone_svg(source.as_str(), viewport())
-            .err()
-            .unwrap_or_else(|| panic!("{id}: an unsupported fixture must refuse under strict"));
-        match SvgFrameSource::from_standalone_svg_best_effort(source.as_str(), viewport()) {
+        let strict = SvgFrameSource::from_standalone_svg_with_fonts(
+            source.as_str(),
+            viewport(),
+            fixture_fonts::unsupported_environment(id),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("{id}: an unsupported fixture must refuse under strict"));
+        match SvgFrameSource::from_standalone_svg_best_effort_with_fonts(
+            source.as_str(),
+            viewport(),
+            fixture_fonts::unsupported_environment(id),
+        ) {
             Err(_) => {
                 writeln!(
                     out,

--- a/crates/websem/tests/support/fixture_fonts.rs
+++ b/crates/websem/tests/support/fixture_fonts.rs
@@ -1,0 +1,20 @@
+//! Declared font environments needed by refusal fixtures.
+
+const ALLERTA_BYTES: &[u8] =
+    include_bytes!("../../../../fixtures/fonts/Allerta/Allerta-Regular.ttf");
+const ALLERTA_SHA256: [u8; 32] = [
+    0x16, 0xd6, 0x91, 0x52, 0x27, 0xc7, 0x56, 0x07, 0x25, 0xc0, 0x37, 0xc9, 0xc9, 0x31, 0x63, 0xcb,
+    0xa5, 0x36, 0x7c, 0x3e, 0xf4, 0xcf, 0x2e, 0xc1, 0x2b, 0xf4, 0x0b, 0x9e, 0xb2, 0x98, 0x4a, 0x6b,
+];
+
+pub(crate) fn unsupported_environment(id: &str) -> textlayout::Environment {
+    if id != "svg-text-geometry-grid" {
+        return textlayout::Environment::default();
+    }
+    textlayout::Environment::new(vec![textlayout::FontResource {
+        key: textlayout::FontKey::new(ALLERTA_SHA256),
+        family: "Allerta".to_string(),
+        face_index: 0,
+        bytes: std::sync::Arc::from(ALLERTA_BYTES),
+    }])
+}

--- a/crates/websem/tests/svg_text_geometry.rs
+++ b/crates/websem/tests/svg_text_geometry.rs
@@ -1,0 +1,559 @@
+//! Rung-B SVG text: real-font artifact geometry, before outline rasterization.
+//!
+//! Chromium directly grades the SVG character-cell facts it exposes. Glyph
+//! ids, clusters, and ink bounds are separately pinned to the exact font
+//! bytes because the browser API exposes no glyph identifier or outline.
+//! Engine pixels are tested only for their own determinism and admission
+//! identity; this suite makes no Chromium real-font pixel claim.
+
+#[allow(dead_code)]
+mod support;
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use websem::{DegradationAction, InitialViewport, SvgFrameSource};
+
+const BUNGEE_BYTES: &[u8] = include_bytes!("../../../fixtures/fonts/Bungee/Bungee-Regular.ttf");
+const BUNGEE_SHA256: &str = "b90c3ca443713b070cb1dec6a3bb1ef7572c2b565c431d9a85d74bbfa07e24cc";
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/web-first/text/geometry")
+}
+
+#[derive(Deserialize)]
+struct Suite {
+    schema_version: u32,
+    font: SuiteFont,
+    cases: Vec<SuiteCase>,
+}
+
+#[derive(Deserialize)]
+struct SuiteFont {
+    family: String,
+    path: String,
+    sha256: String,
+    face_index: u32,
+    license: String,
+    license_sha256: String,
+}
+
+#[derive(Deserialize)]
+struct SuiteCase {
+    id: String,
+    source: String,
+    oracle: String,
+    width: i32,
+    height: i32,
+    text: String,
+    x: String,
+    y: String,
+    text_anchor: String,
+    font_family: String,
+    font_size: String,
+    fill: String,
+    font_facts: FontFacts,
+}
+
+#[derive(Deserialize)]
+struct FontFacts {
+    units_per_em: u16,
+    glyphs: Vec<GlyphFact>,
+    ink_bounds: NumberRect,
+}
+
+#[derive(Deserialize)]
+struct GlyphFact {
+    source_utf8_byte: u32,
+    source_utf16_index: u32,
+    scalar: String,
+    glyph_id: u16,
+    cluster: u32,
+}
+
+#[derive(Deserialize)]
+struct GeometryOracle {
+    schema_version: u32,
+    kind: String,
+    measurement: Measurement,
+}
+
+#[derive(Deserialize)]
+struct Measurement {
+    text_content: String,
+    computed_font_family: String,
+    computed_font_size: String,
+    computed_text_anchor: String,
+    font_ready: bool,
+    number_of_chars: usize,
+    computed_text_length: f64,
+    substring_length: f64,
+    characters: Vec<CharacterGeometry>,
+}
+
+#[derive(Deserialize)]
+struct CharacterGeometry {
+    utf16_code_unit: u32,
+    substring_length: f64,
+    start: NumberPoint,
+    end: NumberPoint,
+    extent: NumberRect,
+    rotation: f64,
+}
+
+#[derive(Deserialize)]
+struct NumberPoint {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Deserialize)]
+struct NumberRect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
+#[derive(Deserialize)]
+struct BakeManifest {
+    schema_version: u32,
+    kind: String,
+    browser_version: String,
+    suite: String,
+    suite_sha256: String,
+    bake_script: String,
+    bake_script_sha256: String,
+    capture_module: String,
+    capture_module_sha256: String,
+    font: BakeFont,
+    records: Vec<BakeRecord>,
+}
+
+#[derive(Deserialize)]
+struct BakeFont {
+    sha256: String,
+    face_index: u32,
+    license_sha256: String,
+}
+
+#[derive(Deserialize)]
+struct BakeRecord {
+    id: String,
+    source: String,
+    source_sha256: String,
+    oracle: String,
+    oracle_sha256: String,
+    width: i32,
+    height: i32,
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
+    let bytes =
+        std::fs::read(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+fn suite() -> Suite {
+    let suite: Suite = read_json(&fixture_root().join("cases.json"));
+    assert_eq!(suite.schema_version, 1);
+    assert!(!suite.cases.is_empty());
+    suite
+}
+
+fn sha256_file(path: &Path) -> String {
+    let bytes =
+        std::fs::read(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn hex_bytes(hex: &str) -> [u8; 32] {
+    assert_eq!(hex.len(), 64);
+    let mut out = [0; 32];
+    for (index, slot) in out.iter_mut().enumerate() {
+        *slot = u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16).expect("hex digest");
+    }
+    out
+}
+
+fn font_bytes(suite: &Suite) -> Arc<[u8]> {
+    std::fs::read(fixture_root().join(&suite.font.path))
+        .expect("pinned real-font bytes")
+        .into()
+}
+
+fn environment(suite: &Suite, bytes: &Arc<[u8]>) -> textlayout::Environment {
+    textlayout::Environment::new(vec![textlayout::FontResource {
+        key: textlayout::FontKey::new(hex_bytes(&suite.font.sha256)),
+        family: suite.font.family.clone(),
+        face_index: suite.font.face_index,
+        bytes: Arc::clone(bytes),
+    }])
+}
+
+fn bungee_environment() -> textlayout::Environment {
+    let digest = Sha256::digest(BUNGEE_BYTES);
+    assert_eq!(format!("{digest:x}"), BUNGEE_SHA256);
+    textlayout::Environment::new(vec![textlayout::FontResource {
+        key: textlayout::FontKey::new(digest.into()),
+        family: "Bungee".to_string(),
+        face_index: 0,
+        bytes: Arc::from(BUNGEE_BYTES),
+    }])
+}
+
+fn canonical_source(case: &SuiteCase) -> String {
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{}\" height=\"{}\">\n  \
+         <text x=\"{}\" y=\"{}\" text-anchor=\"{}\" font-family=\"{}\" \
+         font-size=\"{}\" fill=\"{}\">{}</text>\n</svg>\n",
+        case.width,
+        case.height,
+        case.x,
+        case.y,
+        case.text_anchor,
+        case.font_family,
+        case.font_size,
+        case.fill,
+        case.text
+    )
+}
+
+fn exact(label: &str, artifact: f32, chromium: f64) {
+    assert_eq!(
+        f64::from(artifact),
+        chromium,
+        "{label}: artifact binary32 promoted to binary64 must equal Chromium exactly"
+    );
+}
+
+fn parse_number(label: &str, source: &str) -> f32 {
+    source
+        .parse::<f32>()
+        .unwrap_or_else(|error| panic!("{label} {source:?}: {error}"))
+}
+
+#[test]
+fn geometry_suite_is_closed_and_hash_pinned() {
+    let root = fixture_root();
+    let suite = suite();
+    let manifest: BakeManifest = read_json(&root.join("oracle-bake.json"));
+    assert_eq!(manifest.schema_version, 1);
+    assert_eq!(manifest.kind, "chromium-svg-text-geometry-oracle");
+    assert_eq!(manifest.browser_version, "149.0.7827.55");
+    assert_eq!(manifest.suite, "cases.json");
+    assert_eq!(manifest.bake_script, "bake_chromium.ts");
+    assert_eq!(manifest.capture_module, "../../chromium_capture.ts");
+    assert_eq!(
+        manifest.suite_sha256,
+        sha256_file(&root.join(&manifest.suite))
+    );
+    assert_eq!(
+        manifest.bake_script_sha256,
+        sha256_file(&root.join(&manifest.bake_script))
+    );
+    assert_eq!(
+        manifest.capture_module_sha256,
+        sha256_file(&root.join(&manifest.capture_module))
+    );
+    assert_eq!(suite.font.sha256, sha256_file(&root.join(&suite.font.path)));
+    assert_eq!(
+        suite.font.license_sha256,
+        sha256_file(&root.join(&suite.font.license))
+    );
+    assert_eq!(manifest.font.sha256, suite.font.sha256);
+    assert_eq!(manifest.font.face_index, suite.font.face_index);
+    assert_eq!(manifest.font.license_sha256, suite.font.license_sha256);
+    assert_eq!(manifest.records.len(), suite.cases.len());
+
+    let sources: BTreeSet<String> = std::fs::read_dir(&root)
+        .expect("geometry root")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("svg"))
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    let declared_sources: BTreeSet<String> =
+        suite.cases.iter().map(|case| case.source.clone()).collect();
+    assert_eq!(
+        sources, declared_sources,
+        "every geometry source is enumerated"
+    );
+
+    let oracle_root = root.join("chromium");
+    let oracles: BTreeSet<String> = std::fs::read_dir(&oracle_root)
+        .expect("geometry oracle root")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .map(|entry| format!("chromium/{}", entry.file_name().to_string_lossy()))
+        .collect();
+    let declared_oracles: BTreeSet<String> =
+        suite.cases.iter().map(|case| case.oracle.clone()).collect();
+    assert_eq!(
+        oracles, declared_oracles,
+        "every geometry oracle is enumerated"
+    );
+
+    assert!(suite.cases.windows(2).all(|pair| pair[0].id < pair[1].id));
+    for (case, record) in suite.cases.iter().zip(&manifest.records) {
+        assert_eq!(case.source, record.source);
+        assert_eq!(case.oracle, record.oracle);
+        assert_eq!(case.id, record.id);
+        assert_eq!((case.width, case.height), (record.width, record.height));
+        assert_eq!(
+            canonical_source(case),
+            std::fs::read_to_string(root.join(&case.source)).expect("canonical source")
+        );
+        assert_eq!(record.source_sha256, sha256_file(&root.join(&case.source)));
+        assert_eq!(record.oracle_sha256, sha256_file(&root.join(&case.oracle)));
+    }
+}
+
+#[test]
+fn resolved_artifacts_match_chromium_geometry_exactly() {
+    let suite = suite();
+    let bytes = font_bytes(&suite);
+    let environment = environment(&suite, &bytes);
+    let face = rustybuzz::ttf_parser::Face::parse(&bytes, suite.font.face_index)
+        .expect("pinned face parses for direct cmap checks");
+
+    for case in &suite.cases {
+        let oracle: GeometryOracle = read_json(&fixture_root().join(&case.oracle));
+        assert_eq!(oracle.schema_version, 1);
+        assert_eq!(oracle.kind, "chromium-svg-text-geometry");
+        let measured = oracle.measurement;
+        assert!(measured.font_ready);
+        assert_eq!(measured.text_content, case.text);
+        assert_eq!(measured.computed_font_family, suite.font.family);
+        assert_eq!(measured.computed_font_size, format!("{}px", case.font_size));
+        assert_eq!(measured.computed_text_anchor, case.text_anchor);
+
+        let font_size = parse_number("font-size", &case.font_size);
+        let x = parse_number("x", &case.x);
+        let y = parse_number("y", &case.y);
+        let layout = textlayout::resolve(
+            &textlayout::AttributedText {
+                text: case.text.clone(),
+                style: textlayout::Style {
+                    family: case.font_family.clone(),
+                    size: font_size,
+                },
+            },
+            &environment,
+        )
+        .expect("rung-B artifact resolves");
+        assert_eq!(
+            layout.face().key,
+            textlayout::FontKey::new(hex_bytes(&suite.font.sha256))
+        );
+        assert_eq!(layout.face().face_index, suite.font.face_index);
+        assert_eq!(layout.face().units_per_em, case.font_facts.units_per_em);
+        assert_eq!(layout.source(), case.text);
+        assert_eq!(layout.font_size(), font_size);
+        assert_eq!(layout.glyphs().len(), case.font_facts.glyphs.len());
+        assert_eq!(measured.number_of_chars, case.font_facts.glyphs.len());
+        assert_eq!(measured.characters.len(), case.font_facts.glyphs.len());
+        exact(
+            "run advance",
+            layout.advance(),
+            measured.computed_text_length,
+        );
+        exact(
+            "whole substring",
+            layout.advance(),
+            measured.substring_length,
+        );
+
+        let anchor_start = match case.text_anchor.as_str() {
+            "start" => x,
+            "middle" => x - layout.advance() / 2.0,
+            "end" => x - layout.advance(),
+            other => panic!("unrecognized anchor {other}"),
+        };
+        let metrics = layout.metrics();
+        for (index, ((glyph, fact), character)) in layout
+            .glyphs()
+            .iter()
+            .zip(&case.font_facts.glyphs)
+            .zip(&measured.characters)
+            .enumerate()
+        {
+            let scalar = fact.scalar.chars().next().expect("one scalar fact");
+            assert_eq!(fact.scalar.chars().count(), 1);
+            assert!(scalar.is_ascii() && !scalar.is_ascii_control());
+            assert_eq!(u32::from(scalar), character.utf16_code_unit);
+            assert_eq!(fact.source_utf8_byte as usize, index);
+            assert_eq!(fact.source_utf16_index as usize, index);
+            assert_eq!(fact.source_utf8_byte, fact.cluster);
+            assert_eq!(glyph.cluster, fact.cluster);
+            assert_eq!(glyph.glyph_id, fact.glyph_id);
+            assert_eq!(fact.source_utf16_index, fact.source_utf8_byte);
+            assert_eq!(
+                face.glyph_index(scalar).expect("direct cmap glyph").0,
+                fact.glyph_id,
+                "glyph identity is inferred from the pinned cmap, not a browser API"
+            );
+
+            exact(
+                "character advance",
+                glyph.advance,
+                character.substring_length,
+            );
+            exact(
+                "character start x",
+                anchor_start + glyph.x,
+                character.start.x,
+            );
+            exact("character baseline y", y, character.start.y);
+            exact(
+                "character end x",
+                anchor_start + glyph.x + glyph.advance,
+                character.end.x,
+            );
+            exact("character end y", y, character.end.y);
+            exact(
+                "character cell x",
+                anchor_start + glyph.x,
+                character.extent.x,
+            );
+            exact("character cell y", y - metrics.ascent, character.extent.y);
+            exact(
+                "character cell width",
+                glyph.advance,
+                character.extent.width,
+            );
+            exact(
+                "character cell height",
+                metrics.ascent + metrics.descent,
+                character.extent.height,
+            );
+            assert_eq!(character.rotation, 0.0);
+        }
+
+        let ink = layout.ink_bounds().expect("real face has outline ink");
+        exact("ink x", ink.x, case.font_facts.ink_bounds.x);
+        exact("ink y", ink.y, case.font_facts.ink_bounds.y);
+        exact("ink width", ink.width, case.font_facts.ink_bounds.width);
+        exact("ink height", ink.height, case.font_facts.ink_bounds.height);
+    }
+}
+
+#[test]
+fn real_font_pixels_obey_only_the_engine_laws() {
+    let suite = suite();
+    let bytes = font_bytes(&suite);
+    for case in &suite.cases {
+        let source = std::fs::read_to_string(fixture_root().join(&case.source)).unwrap();
+        let font_size = parse_number("font-size", &case.font_size);
+        let x = parse_number("x", &case.x);
+        let y = parse_number("y", &case.y);
+        let layout = textlayout::resolve(
+            &textlayout::AttributedText {
+                text: case.text.clone(),
+                style: textlayout::Style {
+                    family: case.font_family.clone(),
+                    size: font_size,
+                },
+            },
+            &environment(&suite, &bytes),
+        )
+        .expect("rung-B artifact resolves for frame projection");
+        let anchor_start = match case.text_anchor.as_str() {
+            "start" => x,
+            "middle" => x - layout.advance() / 2.0,
+            "end" => x - layout.advance(),
+            other => panic!("unrecognized anchor {other}"),
+        };
+        let ink = layout
+            .ink_bounds()
+            .expect("geometry witness has outline ink");
+        let strict = SvgFrameSource::from_standalone_svg_with_fonts(
+            source.as_str(),
+            InitialViewport::new(case.width as f32, case.height as f32),
+            environment(&suite, &bytes),
+        )
+        .unwrap_or_else(|error| panic!("{} strict compile: {error}", case.id))
+        .base_frame();
+        let best = SvgFrameSource::from_standalone_svg_best_effort_with_fonts(
+            source.as_str(),
+            InitialViewport::new(case.width as f32, case.height as f32),
+            environment(&suite, &bytes),
+        )
+        .unwrap_or_else(|error| panic!("{} best compile: {error}", case.id));
+        let substantive: Vec<_> = best
+            .degradations()
+            .iter()
+            .filter(|item| item.action() != DegradationAction::SamplesAsBase)
+            .collect();
+        assert!(substantive.is_empty(), "{}: {substantive:?}", case.id);
+
+        assert_eq!(strict.nodes().len(), 1);
+        let bounds = strict.nodes()[0].bounds;
+        assert_eq!(
+            (bounds.x, bounds.y, bounds.width, bounds.height),
+            (anchor_start + ink.x, y + ink.y, ink.width, ink.height,),
+            "the lowered path projects the pinned outline bounds"
+        );
+        let first = support::render_through_n0(&strict, case.width, case.height);
+        let again = support::render_through_n0(&strict, case.width, case.height);
+        let best_pixels = support::render_through_n0(&best.base_frame(), case.width, case.height);
+        assert_eq!(first, again, "{}: fresh renders differ", case.id);
+        assert_eq!(first, best_pixels, "{}: admissions differ", case.id);
+        assert!(
+            first.chunks_exact(4).any(|pixel| pixel[3] != 0),
+            "{}: the clipped real-font witness must paint",
+            case.id
+        );
+    }
+}
+
+#[test]
+fn vertical_query_metric_grid_refuses_when_horizontal_boundaries_are_exact() {
+    let suite = suite();
+    let bytes = font_bytes(&suite);
+    let source = r##"<svg xmlns="http://www.w3.org/2000/svg" width="400" height="100"><text x="0" y="80" text-anchor="start" font-family="Allerta" font-size="80" fill="#000">Hxi</text></svg>"##;
+    let strict = SvgFrameSource::from_standalone_svg_with_fonts(
+        source,
+        InitialViewport::new(400.0, 100.0),
+        environment(&suite, &bytes),
+    )
+    .expect_err("fractional query metrics must not lower silently");
+    assert!(strict.to_string().contains("query metrics"));
+
+    let best = SvgFrameSource::from_standalone_svg_best_effort_with_fonts(
+        source,
+        InitialViewport::new(400.0, 100.0),
+        environment(&suite, &bytes),
+    )
+    .expect("best effort declares and skips the run");
+    assert!(best.base_frame().nodes().is_empty());
+    assert!(best.degradations().iter().any(|item| {
+        item.path().ends_with("/text[1]") && item.reason().contains("query metrics")
+    }));
+}
+
+#[test]
+fn horizontal_query_grid_refuses_when_vertical_metrics_are_integral() {
+    let source = r##"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"><text x="0" y="60" text-anchor="start" font-family="Bungee" font-size="50" fill="#000">Hxi</text></svg>"##;
+    let strict = SvgFrameSource::from_standalone_svg_with_fonts(
+        source,
+        InitialViewport::new(200.0, 100.0),
+        bungee_environment(),
+    )
+    .expect_err("off-grid horizontal boundaries must not lower silently");
+    assert!(strict.to_string().contains("1/64 SVG text query grid"));
+
+    let best = SvgFrameSource::from_standalone_svg_best_effort_with_fonts(
+        source,
+        InitialViewport::new(200.0, 100.0),
+        bungee_environment(),
+    )
+    .expect("best effort declares and skips the run");
+    assert!(best.base_frame().nodes().is_empty());
+    assert!(best.degradations().iter().any(|item| {
+        item.path().ends_with("/text[1]") && item.reason().contains("1/64 SVG text query grid")
+    }));
+}

--- a/crates/websem/tests/unsupported_corpus.rs
+++ b/crates/websem/tests/unsupported_corpus.rs
@@ -16,6 +16,9 @@
 //! attributable and best-effort declares it by name at a stable path. There is
 //! no third outcome, and a fixture that started rendering would land in it.
 
+#[path = "support/fixture_fonts.rs"]
+mod fixture_fonts;
+
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -932,6 +935,11 @@ const CORPUS: &[(&str, Departure, &str)] = &[
     ),
     ("svg-text-font-size-var", DeclaredByBestEffort, "var()"),
     (
+        "svg-text-geometry-grid",
+        DeclaredByBestEffort,
+        "Chromium SVG text query",
+    ),
+    (
         "svg-text-undeclared-font",
         DeclaredByBestEffort,
         "not in the declared environment",
@@ -992,9 +1000,13 @@ fn every_unsupported_fixture_departs_by_name_in_both_admissions() {
         let source = fs::read_to_string(corpus_root().join(format!("{id}.svg")))
             .unwrap_or_else(|error| panic!("{id}: read: {error}"));
 
-        let strict = SvgFrameSource::from_standalone_svg(source.as_str(), viewport())
-            .err()
-            .unwrap_or_else(|| panic!("{id}: strict must refuse an unsupported fixture"));
+        let strict = SvgFrameSource::from_standalone_svg_with_fonts(
+            source.as_str(),
+            viewport(),
+            fixture_fonts::unsupported_environment(id),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("{id}: strict must refuse an unsupported fixture"));
         assert!(
             strict.to_string().contains(named),
             "{id}: the strict refusal must name {named:?}; got {strict}"
@@ -1002,21 +1014,27 @@ fn every_unsupported_fixture_departs_by_name_in_both_admissions() {
 
         match departure {
             BothRefuse => {
-                let best =
-                    SvgFrameSource::from_standalone_svg_best_effort(source.as_str(), viewport())
-                        .err()
-                        .unwrap_or_else(|| {
-                            panic!("{id}: a document-level contract refuses in both admissions")
-                        });
+                let best = SvgFrameSource::from_standalone_svg_best_effort_with_fonts(
+                    source.as_str(),
+                    viewport(),
+                    fixture_fonts::unsupported_environment(id),
+                )
+                .err()
+                .unwrap_or_else(|| {
+                    panic!("{id}: a document-level contract refuses in both admissions")
+                });
                 assert!(
                     best.to_string().contains(named),
                     "{id}: the best-effort refusal must name {named:?}; got {best}"
                 );
             }
             DeclaredByBestEffort => {
-                let best =
-                    SvgFrameSource::from_standalone_svg_best_effort(source.as_str(), viewport())
-                        .unwrap_or_else(|error| panic!("{id}: best-effort compiles: {error}"));
+                let best = SvgFrameSource::from_standalone_svg_best_effort_with_fonts(
+                    source.as_str(),
+                    viewport(),
+                    fixture_fonts::unsupported_environment(id),
+                )
+                .unwrap_or_else(|error| panic!("{id}: best-effort compiles: {error}"));
                 let declared: Vec<&websem::Degradation> = best
                     .degradations()
                     .iter()

--- a/docs/wg/consolidation/index.md
+++ b/docs/wg/consolidation/index.md
@@ -71,7 +71,7 @@ that decision is settled:
 | [how the mature Web renderer enters](./web-renderer-adoption.md) | patrol | (evidence for D-M) | which capability is reusable, which topology must not cross |
 | [the SVG engine of record](./svg-engine-of-record.md) | finding | D-N — the n0 path is the one product path for SVG, static and animated | **taken** 2026-07-24; settles routing and succession, not capability |
 | [the conformance-bar flip rule](./flip-rule.md) | proposal | FLIP — thresholds, coverage, oracle discipline | **unratified** ([gridaco/nothing#49](https://github.com/gridaco/nothing/issues/49)); **no score may be produced or inspected** |
-| [the text oracle method](./text-oracle.md) | finding | how text is gated on the engine of record: the deterministic-font rung, the admitted numeric domain, the hermetic font environment, the corpus-growth law | **ratified** 2026-08-04 ([gridaco/nothing#68](https://github.com/gridaco/nothing/pull/68)); binds the text rungs; the D-M text stage it left open closed low 2026-08-05 |
+| [the text oracle method](./text-oracle.md) | finding | how text is gated on the engine of record: the deterministic-font rung, the admitted numeric domain, the hermetic font environment, the corpus-growth law | **ratified** 2026-08-04 ([gridaco/nothing#68](https://github.com/gridaco/nothing/pull/68)); binds the text rungs; the D-M text stage it left open closed low 2026-08-05; real-font geometry Rung B first exercised 2026-09-01 |
 | [lock-graph-changes.toml](./lock-graph-changes.toml) | gate ledger | (records moves D-L authorises) | read by `bin/check-cargo-lock-additions-only` |
 
 D-N demotes the mature Web renderer to a frozen semantics donor, with declared

--- a/docs/wg/consolidation/svg-engine-of-record.md
+++ b/docs/wg/consolidation/svg-engine-of-record.md
@@ -85,23 +85,25 @@ from the dated addenda below:
   viewport clips, solid/context-solid source programs, `<use>` clients, and
   client transform/opacity/clip/mask/filter composition;
   one declared-font, single-run `<text>` profile, with direct invariant
-  number/`px` size sources and a final identity-linear, integer-translation
-  device mapping after root, ancestor, and instance composition; viewBox-only
+  number/`px` size sources, a final identity-linear, integer-translation
+  device mapping after root, ancestor, and instance composition, and one
+  real-font artifact-geometry witness graded exactly before rasterization;
+  viewBox-only
   root sizing with the full `preserveAspectRatio` grammar; and one exact-time
   `<animate attributeName="x">` on a top-level `<rect>`, including a client
   carrying admitted repeating-pattern paint and admitted source/target filter
   composition.
   `crates/n0_cli/README.md` is the statement of record.
 - **The corpus** is 1,051 Chromium-baked primitive cells plus 16 sampled frames,
-  with a separate nine-cell exact Ahem text suite under the ratified text
-  corpus-growth law.
+  with a separate nine-cell exact Ahem text suite and one exact-number Allerta
+  artifact-geometry witness under the ratified text corpus-growth law.
   All byte-exact except seven curved cells carrying a declared, geometrically
   confined tolerance (the native-oval/conic boundary) and four gradient cells
   carrying a declared one-code-value ramp-quantization tolerance (one pixel
   against Chromium's Skia; 18 knife-edge pixels between this engine's own
   macOS and Linux Skia builds; 336 ramp pixels under an isolated layer's
   restore; 576 after a masked ramp becomes luminance alpha). The named refusal
-  register has 206 rows.
+  register has 207 rows.
 - **Not claimed:** no conformance score exists or may be computed — FLIP is
   unratified. The FLIP record and identity-changing review are prepared, but
   only the owner act on gridaco/nothing#49 may authorize them and the first
@@ -4665,3 +4667,72 @@ artifact-geometry gate described by the ratified
 [text-oracle method](./text-oracle.md); it does not depend on ambient font
 discovery. No conformance score was produced, and no FLIP record, rule, or
 baseline changed.
+
+## Rung: SVG real-font artifact geometry (2026-09-01)
+
+The verdict is T2 EXERCISED, with no checklist closure. One exact declared
+real face and one horizontal LTR run now reach the Rung-B geometry gate from
+the [text-oracle method](./text-oracle.md). This checkpoint grades the resolved
+artifact before outline rasterization. It does not claim Chromium-identical
+real-font pixels, wider shaping, family selection, fallback, or any complete
+font/text grammar.
+
+The selected identity is Allerta Regular, face index 0, 16,248 bytes, pinned by
+SHA-256 under the SIL Open Font License 1.1. Its committed `Hxi` witness uses a
+5120px size and middle anchor. Chromium 149.0.7827.55 directly exposes total
+and substring advance 8600, character advances 3745/3400/1455, starts
+0/3745/7145, baseline 4080, and logical cell top/height -1205/6545. Every
+browser-visible number equals the artifact's corresponding binary32 fact after
+exact promotion to binary64; no rounding or tolerance intervenes.
+
+The direct browser record is deliberately narrower than the complete artifact.
+SVG text queries index source text in UTF-16 code units and expose no glyph id
+or outline-ink box. The gate therefore records those as separate pinned-font
+facts: 1024 units per em, direct-map glyph ids 42/88/73, UTF-8 clusters 0/1/2,
+and outline union `(470, -4080, 7765, 4080)`. Printable ASCII makes the two
+source index spaces coincide for this witness only. The resolved font identity
+and glyphs still lower away before the shared frame; no text or resource fact
+was added there.
+
+The probe found two browser normalization stages that a clean render had
+hidden. Horizontal SVG character cells enclose their boundaries on a 1/64
+CSS-pixel fixed grid; vertical cells expose integral fixed ascent/descent
+metrics. At 1000px the artifact's first advance is 731.4453125 while Chromium
+reports 731.453125, and its ascent is 1032.2265625 while the browser cell uses
+1032. The 80px probe separates the vertical stage from an already-exact
+horizontal stage; 85px and 1000px differ on both; 5120px is exact on both
+(measured, not celled except for the committed 5120px witness).
+A separate Bungee 50px probe makes ascent/descent integral at 51/15 while its
+first artifact advance 37.95 is exposed as 37.953125, independently guarding
+the horizontal stage (measured, not celled; negative-only).
+
+The producer does not copy Chromium's projection back into the artifact.
+Every glyph start/end must already lie on the 1/64 grid and both metrics must
+already be integral, or the text node leaves by the stable
+`Chromium SVG text query` reason. The 1000px route is now a registered refusal:
+strict stops there, while best effort skips and declares that same node. Before
+the guard, both admissions rendered it cleanly; a supporting scratch raster
+comparison differed from Chromium at 8,310 pixels with maximum channel delta
+170 (measured, not celled and not promoted into a browser-pixel claim).
+
+No second class appeared in the selected face's sampled `fi` and `AV` runs
+(measured, not celled). That does not generalize them: ligatures, kerning,
+nonzero offsets, wider clusters, non-ASCII repertoire, and multi-run text are
+the next shaping work. Engine pixels for the committed witness are guarded
+only for deterministic repetition, non-empty realization, and strict/best
+identity.
+
+Gate sensitivity was proved at the producer boundary. Temporarily bypassing
+the query-geometry admission allowed both isolated negative runs to lower. The
+full gate passed the unrelated primitive and Ahem estates, then failed loudly
+on both the vertical-only Allerta 80px and horizontal-only Bungee 50px
+contracts. Restoring the boundary returned the complete gate and refusal
+register to green. Independently changing the recorded run length by exactly
+1/64 failed the exact numeric gate, and attempting to register the same
+geometry identity again refused rather than replacing its source or oracle.
+
+The primitive corpus remains 1,051 Chromium-baked cells plus 16 sampled
+frames. The exact Ahem suite remains nine cells; the new Allerta suite carries
+one exact-number geometry witness. One query-grid refusal moves the named
+register from 206 to 207. No conformance score was produced, and no FLIP
+record, rule, or baseline changed.

--- a/docs/wg/consolidation/text-oracle.md
+++ b/docs/wg/consolidation/text-oracle.md
@@ -54,9 +54,9 @@ construct enters the corpus only under a rung that can actually grade it.
 | **B — geometry oracle** | Chromium's SVG text measurement APIs (`getExtentOfChar`, `getComputedTextLength`, …) captured under the bake posture grade the *resolved artifact's geometry* for real fonts; pixels are governed by the engine's own laws (reuse ≡ fresh), not graded against Chromium | Shaping facts with real fonts: cluster extents, advances, anchoring | Any pixel claim |
 | **C — thresholded raster** | Perceptual/threshold pixel comparison | — | **Parked.** Requires an owner decision adjacent to FLIP; never lands as a score. |
 
-Rung A is the only rung text-0 asks to ratify. Rung B is named now so the
-real-font milestone (text-3+) has a destination; it is not exercised. Rung C
-exists so nobody reinvents it informally.
+Rung A was the only rung text-0 asked the owner to activate. Rung B was then
+exercised on 2026-09-01 by the real-font geometry addendum below. Rung C exists
+so nobody reinvents it informally; it remains parked.
 
 ## The probe record
 
@@ -252,5 +252,70 @@ Ratifying this brief decides:
    artifact; refuses font discovery, paint, clocks, and estimates — with an
    architecture test forbidding ambient font access.
 
-What this brief does **not** decide: the D-M shaped-text join, rung C, and any
-real-font method detail beyond naming rung B as its destination.
+What the original ratification did **not** decide: the D-M shaped-text join,
+rung C, and any real-font method detail beyond naming rung B as its
+destination. D-M later closed low; the following evidence addendum records the
+first execution of B without reopening either decision.
+
+## Rung-B evidence addendum — real-font artifact geometry (2026-09-01)
+
+The verdict is EXERCISED for one exact real face and one horizontal LTR run.
+This is an evidence checkpoint, not completion of `<text>` or any broad font,
+shaping, or text-layout grammar.
+
+The selected identity is the redistributable Allerta Regular face, index 0,
+16,248 bytes, SHA-256
+`16d6915227c7560725c037c9c93163cba5367c3ef4cf2ec12bf40b9eb2984a6b`, under
+the SIL Open Font License 1.1. The committed witness uses `Hxi` at 5120 CSS
+pixels with middle anchoring. That size is evidence-driven: it makes both
+normalization stages below exact, rather than rounding the record until it
+looks equal.
+
+The evidence keeps direct browser facts and pinned-font facts separate.
+Chromium's standard SVG text APIs directly report the run length, substring
+lengths, character starts, ends, extents, rotations, anchor placement, and
+source character indexing. Those APIs index source text in UTF-16 code units.
+They expose neither glyph identifiers nor outline-ink bounds. Glyph identity,
+units-per-em, UTF-8 cluster mapping, and ink bounds are therefore verified
+independently against the exact declared font bytes and are never described as
+Chromium measurements. Printable ASCII makes the witness's UTF-8 and UTF-16
+positions both 0/1/2; later repertoires may not assume that coincidence.
+
+The comparison is exact and representation-aware. A browser JSON number is an
+IEEE-754 binary64 value; each artifact binary32 number is promoted to binary64
+and compared for equality. There is no decimal pre-rounding, epsilon, or image
+threshold. For the committed witness Chromium reports total advance 8600,
+individual advances 3745/3400/1455, character starts 0/3745/7145, baseline
+4080, and character-cell top/height -1205/6545. The artifact states those
+browser-visible facts exactly. Its separate font-derived record names glyphs
+42/88/73, 1024 units per em, clusters 0/1/2, and outline union
+`(470, -4080, 7765, 4080)`.
+
+Measurement found two normalization stages at the browser boundary. Horizontal
+character cells enclose their start and end on a 1/64 CSS-pixel fixed grid;
+vertical cells expose integral fixed ascent and descent. Probes at 80, 85,
+1000, and 5120 pixels separated them: 80 preserves horizontal geometry but not
+the vertical metrics, 85 and 1000 differ on both, and 5120 is exact on both
+(measured, not celled except for the 5120 witness). At 1000, the artifact's
+first advance is 731.4453125 while Chromium exposes 731.453125, and the
+artifact ascent is 1032.2265625 while Chromium's character cell uses 1032.
+A separate Bungee 50px probe isolates the horizontal stage: its ascent and
+descent are already integral at 51/15, while the artifact's first 37.95
+advance is exposed as 37.953125 (measured, not celled). That face is a
+negative-only boundary witness, not a second positive geometry oracle.
+
+The method does not normalize the artifact to those values. Geometry that
+would change at either projection departs by a stable text-specific name before
+rasterization: strict refuses, while best effort skips and declares the text
+node. That boundary is conservative until a later oracle version deliberately
+owns the normalization.
+The selected face's sampled `fi` and `AV` runs exposed no second shaping class
+(measured, not celled); ligature, kerning, nonzero-offset, and wider cluster
+semantics remain outside this checkpoint.
+
+Real-font pixels remain outside the claim. The engine raster is guarded for
+determinism, non-empty realization, and identity between its admission
+policies, but it is never compared with Chromium and receives no tolerance.
+The resolved font and glyph identity still disappear before the shared frame;
+Rung B requires no new shared render fact. The complete evidence record and
+tooling live in the [text fixture estate](../../../fixtures/web-first/text/README.md).

--- a/docs/wg/consolidation/web-checklist.md
+++ b/docs/wg/consolidation/web-checklist.md
@@ -1827,6 +1827,17 @@ for attributes the platform ships ahead of the SVG 2 indexes.
 > shaping, positioning, font selection, and text layout remain outside the
 > profile, so the `<text>` row stays open.
 
+> **2026-09-01 real-font geometry checkpoint:** Rung B now has one committed
+> Allerta artifact witness. Chromium's SVG text-query APIs grade total and
+> per-character advance, start/end, logical extent, baseline, rotation, and
+> middle-anchor placement by exact number; glyph ids, clusters, units-per-em,
+> and outline ink are separately pinned to the exact font bytes because the
+> browser APIs do not expose them. A 1000px control proves the browser's 1/64
+> horizontal enclosure and integral vertical-metric projection would change
+> the artifact, so that class now refuses by stable name in both admissions;
+> the named register moves from 206 to 207. Real-font pixels make no Chromium
+> claim, wider shaping remains open, and no element row ticks.
+
 
 ### SVG presentation attributes
 
@@ -1936,6 +1947,13 @@ for attributes the platform ships ahead of the SVG 2 indexes.
 > the primitive corpus remains 1,051 cells plus 16 sampled frames, and the
 > separate text suite moves from six to nine exact cells. The full SVG
 > presentation-attribute grammar remains open, so no font/text row ticks.
+
+> **2026-09-01 real-font geometry checkpoint:** the new one-witness numeric
+> gate validates one exact face/run only. It adds no family selection,
+> fallback, style/weight/stretch, wider `font-size` source grammar, or font
+> property admission. The Ahem pixel suite remains nine exact cells, the
+> separate Allerta geometry suite has one exact-number witness, and every
+> broad font row stays open.
 
 - [ ] `glyph-orientation-horizontal`
 - [ ] `glyph-orientation-vertical`

--- a/fixtures/web-first/README.md
+++ b/fixtures/web-first/README.md
@@ -17,14 +17,18 @@ renderer's corpora, which is the distinction this directory name carries.
 
 Every root primitive here is a closed enumeration in `primitives.json` with a
 committed Chromium oracle beside it. Text follows the ratified corpus-growth
-law in its own closed [nine-cell suite](./text/README.md). The current evidence
-estate is 1,051 primitive cells plus 16 sampled frames, nine exact text cells,
-and 206 named refusal rows. The gate is byte equality: what each corpus admits
-is exactly what the engine renders pixel-for-pixel, except only the primitive
-rows carrying an explicit measured tolerance block.
+law in its own closed [text estate](./text/README.md): nine exact Ahem cells and
+one exact-number real-font artifact-geometry witness. The current evidence
+estate is 1,051 primitive cells plus 16 sampled frames, those ten text
+witnesses, and 207 named refusal rows. Pixel cells use byte equality: what each
+corpus admits is exactly what the engine renders pixel-for-pixel, except only
+the primitive rows carrying an explicit measured tolerance block. The
+real-font witness grades geometry before rasterization and makes no Chromium
+pixel claim.
 
 | File | Role |
 | --- | --- |
+| `text/` | The closed text estate: nine exact Ahem pixel cells plus one Allerta artifact-geometry witness; see [`text/README.md`](./text/README.md). |
 | `html-inline-svg-currentcolor-rect.html` | HTML whose `<style> .mark { color:#16a34a }` cascades to a `<rect class="mark">` inside inline `<svg>`. |
 | `svg-currentcolor-rect.svg` | The equivalent standalone SVG (carries `color` via an inline `style`). Renders identically. |
 | `svg-viewbox-uniform-offset-rect.svg` | A non-zero-origin `viewBox` with uniform 2× viewport mapping — the first supported non-identity viewport case. |
@@ -386,17 +390,19 @@ elsewhere in this table.
 
 The loop's per-rung commands live in this directory's `justfile` (`just -l`):
 `bake` (create missing primitive oracles, verify every existing one
-pixel-for-pixel), `gate` (primitive pixels, exact text pixels/contracts, and
-the named refusal register), `text-bake` / `text-gate` (the focused text
-twins), `status` (regenerate
+pixel-for-pixel), `gate` (primitive pixels, exact text pixels, text artifact
+geometry, and the named refusal register), `text-bake` / `text-geometry-bake`
+/ `text-gate` (the focused text tools), `status` (regenerate
 [STATUS.md](./STATUS.md)), `add <id> <source> [entry]` (register a fixture with
 a sorted manifest entry, defaulting to `standalone-svg` and accepting
 `html-inline-svg`, while refusing overwrites), `text-add <id> <source>` (the
-same never-overwrite registration for the dedicated 100×100 text suite), and
-`probe <script>` (run a scratch probe).
+same never-overwrite registration for the dedicated 100×100 pixel suite),
+`text-geometry-add <id> <source> <facts>` (register one real-font numeric
+witness without an oracle overwrite), and `probe <script>` (run a scratch
+probe).
 
 The Chromium capture posture lives in **one module**,
-[`chromium_capture.ts`](./chromium_capture.ts), imported by both bakers and
+[`chromium_capture.ts`](./chromium_capture.ts), imported by all three bakers and
 [`probe_harness.ts`](./probe_harness.ts) — so a probe measures under exactly
 the conditions the cells bake under, and the posture cannot silently drift:
 each `oracle-bake.json` records the module's sha256 and the Rust gates refuse a

--- a/fixtures/web-first/STATUS.md
+++ b/fixtures/web-first/STATUS.md
@@ -1080,7 +1080,7 @@ to its fixture source. No new image is committed for this view.
 <a href="./svg-visibility-rule-beats-attribute.svg" title="svg-visibility-rule-beats-attribute (standalone-svg)"><img src="./chromium/svg-visibility-rule-beats-attribute.png" width="56" alt="svg-visibility-rule-beats-attribute"></a>
 <a href="./svg-visibility-unhide.svg" title="svg-visibility-unhide (standalone-svg)"><img src="./chromium/svg-visibility-unhide.png" width="56" alt="svg-visibility-unhide"></a>
 
-## The refusal register (206)
+## The refusal register (207)
 
 What the slice refuses, by name, in the compiler's own words —
 **both refuse** is a document-level contract; **declared** renders
@@ -1285,6 +1285,7 @@ its row into the cells above.
 | `svg-text-font-size-escape` | declared | skipped svg/text[1]: unsupported computed style: <text> authored font-size carries a CSS escape whose source spelling this text patrol cannot prove |
 | `svg-text-font-size-source` | declared | skipped svg/text[1]: unsupported computed style: <text> authored font-size "5119px" changes under Stylo font-size quantization before the numeric-domain check |
 | `svg-text-font-size-var` | declared | skipped svg/text[1]: unsupported computed style: <text> authored font-size resolves through var(), whose source provenance this text patrol cannot follow |
+| `svg-text-geometry-grid` | declared | skipped svg/text[1]: unsupported computed style: text geometry is outside the admitted numeric domain: Chromium SVG text query metrics would round ascent/descent (1032.2266, 246.09375) to its integer fixed-metric grid |
 | `svg-text-tspan` | declared | skipped svg/text[1]: unsupported element <tspan> |
 | `svg-text-undeclared-font` | declared | skipped svg/text[1]: unsupported computed style: text resolution refused: font family "Undeclared" is not in the declared environment |
 | `svg-use-authored-children` | declared | skipped svg/use[1]: unsupported <use>: it has authored element children, which Chromium replaces with the shadow content |

--- a/fixtures/web-first/animation/oracle-bake.json
+++ b/fixtures/web-first/animation/oracle-bake.json
@@ -6,7 +6,7 @@
   "platform": "darwin-arm64",
   "node_version": "v24.19.0",
   "bake_script_sha256": "379bf2870d5a48e9f25d9c2d7cbab05c36d7ff6b46afcaa43ef25ae548e8dde1",
-  "capture_module_sha256": "15ba5c3156f3ed0bfd0f32b6ad773e1d228c0f678396db08c8de1d972cf5bced",
+  "capture_module_sha256": "c66ee93e4f96d4f5c169254181d7cda14bb4254e07d65f64dec7f32f5bdcb296",
   "suite": "cases.json",
   "suite_sha256": "746a803ebef3848ca06c591b3f74c9657fd83af8f355249cbce0bdba55d080ef",
   "capture": {

--- a/fixtures/web-first/chromium_capture.ts
+++ b/fixtures/web-first/chromium_capture.ts
@@ -1,10 +1,9 @@
 /**
- * The one Chromium capture posture for the Web-first primitive suite.
+ * The one Chromium capture posture for the Web-first suites.
  *
- * Both consumers import this module — `bake_chromium.ts` (the committed
- * oracles) and `probe_harness.ts` (scratch probes) — so a probe measures
- * under exactly the conditions the cells are baked under, instead of a
- * hand-copied posture that can drift. The posture is provenance:
+ * Every baker and `probe_harness.ts` imports this module, so a probe measures
+ * under exactly the conditions the committed evidence is captured under,
+ * instead of a hand-copied posture that can drift. The posture is provenance:
  * `oracle-bake.json` records this file's sha256 alongside the baker's, and
  * `crates/websem/tests/reftest_oracle.rs` refuses a suite whose recorded
  * posture hash is stale.
@@ -14,6 +13,7 @@ import {
   chromium,
   type Browser,
   type BrowserContext,
+  type Locator,
   type Page,
 } from "@playwright/test";
 
@@ -23,9 +23,10 @@ export async function launchDeterministicChromium(): Promise<Browser> {
 
 export async function deterministicContext(
   browser: Browser,
+  options: { javaScriptEnabled?: boolean } = {},
 ): Promise<BrowserContext> {
   const context = await browser.newContext({
-    javaScriptEnabled: false,
+    javaScriptEnabled: options.javaScriptEnabled ?? false,
     viewport: { width: 1280, height: 720 },
     deviceScaleFactor: 1,
     colorScheme: "light",
@@ -45,18 +46,25 @@ export interface SvgCapture {
   label: string;
 }
 
-/**
- * Capture the first `<svg>` element of the source as PNG bytes.
- *
- * standalone-svg (`image/svg+xml`): the window IS the initial viewport
- * (SVG2 §8.2) the declared dims stand for — a missing root width/height is
- * `auto` and resolves to 100% of it. html-inline-svg keeps the context's
- * fixed 1280x720 posture: that entry has no initial-viewport semantics yet.
- */
-export async function captureFirstSvg(
-  page: Page,
-  capture: SvgCapture,
-): Promise<Buffer> {
+/** Declare one exact font identity without putting font bytes in the fixture. */
+export function declareFontInSvg(
+  source: string,
+  family: string,
+  fontBytes: Uint8Array,
+): string {
+  if (!/^[A-Za-z0-9 _-]+$/.test(family)) {
+    throw new Error(`font family ${JSON.stringify(family)} is not safely declarable`);
+  }
+  const fontDataUrl = `data:font/ttf;base64,${Buffer.from(fontBytes).toString("base64")}`;
+  const rule = `<style>@font-face{font-family:${JSON.stringify(family)};src:url(${fontDataUrl})}</style>`;
+  const rootEnd = source.indexOf(">");
+  if (rootEnd < 0 || !source.slice(0, rootEnd).includes("<svg")) {
+    throw new Error("fixture must open with an <svg> root element");
+  }
+  return source.slice(0, rootEnd + 1) + rule + source.slice(rootEnd + 1);
+}
+
+async function loadFirstSvg(page: Page, capture: SvgCapture): Promise<Locator> {
   if (capture.media === "image/svg+xml") {
     await page.setViewportSize({ width: capture.width, height: capture.height });
   }
@@ -73,5 +81,96 @@ export async function captureFirstSvg(
       `${capture.label}: unexpected SVG box ${JSON.stringify(box)}; expected ${capture.width}x${capture.height}`,
     );
   }
+  return svg;
+}
+
+/**
+ * Capture the first `<svg>` element of the source as PNG bytes.
+ *
+ * standalone-svg (`image/svg+xml`): the window IS the initial viewport
+ * (SVG2 §8.2) the declared dims stand for — a missing root width/height is
+ * `auto` and resolves to 100% of it. html-inline-svg keeps the context's
+ * fixed 1280x720 posture: that entry has no initial-viewport semantics yet.
+ */
+export async function captureFirstSvg(
+  page: Page,
+  capture: SvgCapture,
+): Promise<Buffer> {
+  const svg = await loadFirstSvg(page, capture);
   return svg.screenshot({ omitBackground: true, type: "png" });
+}
+
+export interface SvgTextCharacterGeometry {
+  utf16_code_unit: number;
+  substring_length: number;
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+  extent: { x: number; y: number; width: number; height: number };
+  rotation: number;
+}
+
+export interface SvgTextGeometry {
+  text_content: string;
+  computed_font_family: string;
+  computed_font_size: string;
+  computed_text_anchor: string;
+  font_ready: boolean;
+  number_of_chars: number;
+  computed_text_length: number;
+  substring_length: number;
+  characters: SvgTextCharacterGeometry[];
+}
+
+/**
+ * Measure the only `<text>` child of the first SVG through the standard
+ * SVGTextContentElement geometry APIs. The context must have JavaScript
+ * enabled: author scripts remain forbidden by the fixture gate, while this
+ * harness-owned evaluation is the measurement instrument.
+ */
+export async function measureOnlySvgText(
+  page: Page,
+  capture: SvgCapture,
+): Promise<SvgTextGeometry> {
+  const svg = await loadFirstSvg(page, capture);
+  const text = svg.locator("text");
+  if ((await text.count()) !== 1) {
+    throw new Error(`${capture.label}: expected exactly one <text> element`);
+  }
+  await page.evaluate(async () => document.fonts.ready);
+  return text.evaluate((node) => {
+    const element = node as SVGTextContentElement;
+    const style = getComputedStyle(element);
+    const count = element.getNumberOfChars();
+    const content = element.textContent ?? "";
+    const characters = [];
+    for (let index = 0; index < count; index += 1) {
+      const start = element.getStartPositionOfChar(index);
+      const end = element.getEndPositionOfChar(index);
+      const extent = element.getExtentOfChar(index);
+      characters.push({
+        utf16_code_unit: content.charCodeAt(index),
+        substring_length: element.getSubStringLength(index, 1),
+        start: { x: start.x, y: start.y },
+        end: { x: end.x, y: end.y },
+        extent: {
+          x: extent.x,
+          y: extent.y,
+          width: extent.width,
+          height: extent.height,
+        },
+        rotation: element.getRotationOfChar(index),
+      });
+    }
+    return {
+      text_content: content,
+      computed_font_family: style.fontFamily,
+      computed_font_size: style.fontSize,
+      computed_text_anchor: style.textAnchor,
+      font_ready: document.fonts.check(`${style.fontSize} ${style.fontFamily}`, content),
+      number_of_chars: count,
+      computed_text_length: element.getComputedTextLength(),
+      substring_length: element.getSubStringLength(0, count),
+      characters,
+    };
+  });
 }

--- a/fixtures/web-first/fonts/README.md
+++ b/fixtures/web-first/fonts/README.md
@@ -9,6 +9,8 @@ so every entry is pinned by content hash, and a changed byte is a new identity
 | File | sha256 | Bytes | Source | License |
 | --- | --- | --- | --- | --- |
 | `ahem.ttf` | `b719ecb31c5b21fc573c03f6421c74ac63c271a5a3ff841e34f9705fb94b8448` | 21768 | [web-platform-tests/wpt `fonts/Ahem.ttf` @ `986881aa`](https://github.com/web-platform-tests/wpt/blob/986881aaf27ffc441f67dd9e5595e797141b1f40/fonts/Ahem.ttf) | Public domain |
+| [`../../fonts/Allerta/Allerta-Regular.ttf`](../../fonts/Allerta/Allerta-Regular.ttf) | `16d6915227c7560725c037c9c93163cba5367c3ef4cf2ec12bf40b9eb2984a6b` | 16248 | [Google Fonts: Allerta](https://fonts.google.com/specimen/Allerta) | [SIL Open Font License 1.1](../../fonts/Allerta/OFL.txt), license bytes `f81e6bb77d9f3f302d6264545b8abcd09dda0827fb4b62cf811ed59d6fd3a968` |
+| [`../../fonts/Bungee/Bungee-Regular.ttf`](../../fonts/Bungee/Bungee-Regular.ttf) | `b90c3ca443713b070cb1dec6a3bb1ef7572c2b565c431d9a85d74bbfa07e24cc` | 118080 | [Google Fonts: Bungee](https://fonts.google.com/specimen/Bungee) | [SIL Open Font License 1.1](../../fonts/Bungee/OFL.txt), license bytes `d5787a50dde5be6c6daecab9ed459939b1bc37cff0d0e00257eaf1ec2cf4c16c` |
 
 [Ahem](https://web-platform-tests.org/writing-tests/ahem.html) is the font the
 web platform's own test suite uses to make text deterministic: every visible
@@ -16,6 +18,17 @@ glyph is a solid em-square box (ascent 0.8em, descent 0.2em), so at integer
 positions and a font size divisible by 5 a glyph rasterizes with no
 anti-aliasing ambiguity at all. That property is what lets text enter the
 byte-exact Chromium gate without weakening it.
+
+Allerta is the first real-font Rung-B identity. It already lived in the shared
+font fixtures, so the text suite references those exact bytes instead of
+copying them. Its geometry oracle compares resolved artifact numbers with
+Chromium and deliberately makes no browser-pixel claim.
+
+Bungee is a negative-only Rung-B boundary identity. Its 50px metrics are
+integral while its glyph boundaries miss Chromium's 1/64 query grid, so it
+guards that horizontal refusal independently from Allerta's vertical-metric
+case. It is not a positive geometry oracle or a widening of the admitted
+repertoire.
 
 This directory grows only when a rung's admitted slice requires a new pinned
 identity, and never holds a corpus: breadth suites live untracked under

--- a/fixtures/web-first/justfile
+++ b/fixtures/web-first/justfile
@@ -23,14 +23,24 @@ probe file:
 text-bake:
     {{node_env}} pnpm -C {{justfile_directory()}}/../../packages/grida-reftest exec tsx {{justfile_directory()}}/text/bake_chromium.ts
 
+# Bake/verify real-font artifact geometry through Chromium's SVG text DOM
+# measurement APIs. These JSON oracles make no browser-pixel claim.
+text-geometry-bake:
+    {{node_env}} pnpm -C {{justfile_directory()}}/../../packages/grida-reftest exec tsx {{justfile_directory()}}/text/geometry/bake_chromium.ts
+
 # The exact Ahem text gate through websem → rframe → n0.
 text-gate:
     {{cargo_env}} cargo test -p websem --test svg_text
+    {{cargo_env}} cargo test -p websem --test svg_text_geometry
 
 # Register one deterministic-font text cell without overwriting any source or
 # oracle. The default text canvas is 100x100.
 text-add id source:
     python3 {{justfile_directory()}}/text/add_cell.py {{id}} --source {{source}}
+
+# Register one real-font geometry witness plus its pinned-font fact record.
+text-geometry-add id source facts:
+    python3 {{justfile_directory()}}/text/geometry/add_case.py {{id}} --source {{source}} --facts {{facts}}
 
 # The engine gate over every committed cell and named refusal. Primitive rows
 # are byte-exact except where their declared tolerance blocks carry measured
@@ -38,6 +48,7 @@ text-add id source:
 gate:
     {{cargo_env}} cargo test -p websem --test reftest_oracle
     {{cargo_env}} cargo test -p websem --test svg_text
+    {{cargo_env}} cargo test -p websem --test svg_text_geometry
     {{cargo_env}} cargo test -p websem --test unsupported_corpus
 
 # Regenerate STATUS.md and its freshness gate.

--- a/fixtures/web-first/oracle-bake.json
+++ b/fixtures/web-first/oracle-bake.json
@@ -3,7 +3,7 @@
   "kind": "chromium-primitive-suite",
   "browser_version": "149.0.7827.55",
   "bake_script_sha256": "2bdb5f933d072a1e87c9a675c3342fcf506c0955c0f5c26e2988f4e8fa37c4f2",
-  "capture_module_sha256": "15ba5c3156f3ed0bfd0f32b6ad773e1d228c0f678396db08c8de1d972cf5bced",
+  "capture_module_sha256": "c66ee93e4f96d4f5c169254181d7cda14bb4254e07d65f64dec7f32f5bdcb296",
   "suite": "primitives.json",
   "suite_sha256": "fbc3448488f375d0123fb42ba249bc6bda3dd17ba099d3ea18517f90cc0bd086",
   "capture": {

--- a/fixtures/web-first/probe_harness.ts
+++ b/fixtures/web-first/probe_harness.ts
@@ -29,6 +29,8 @@ import {
   captureFirstSvg,
   deterministicContext,
   launchDeterministicChromium,
+  measureOnlySvgText,
+  type SvgTextGeometry,
 } from "./chromium_capture";
 
 export interface ProbeComparison {
@@ -114,4 +116,59 @@ export async function runProbeMatrix(matrix: ProbeMatrix): Promise<void> {
 
   await context.close();
   await browser.close();
+}
+
+export interface TextGeometryProbeMatrix {
+  /** id -> standalone SVG source with its exact font declared inline. */
+  probes: Record<string, string>;
+  /** Where exact JSON measurements are written (scratch space). */
+  outDir: string;
+  width: number;
+  height: number;
+}
+
+/**
+ * Measure SVG text geometry twice per source and require exact structural
+ * equality. The shared capture module owns navigation, context posture, and
+ * the measurement API calls, so a scratch probe and committed bake cannot
+ * silently become two Chromium instruments.
+ */
+export async function runTextGeometryProbe(
+  matrix: TextGeometryProbeMatrix,
+): Promise<Record<string, SvgTextGeometry>> {
+  await mkdir(matrix.outDir, { recursive: true });
+  const browser = await launchDeterministicChromium();
+  console.log(`chromium ${browser.version()}`);
+  const context = await deterministicContext(browser, {
+    javaScriptEnabled: true,
+  });
+  const results: Record<string, SvgTextGeometry> = {};
+  try {
+    for (const [id, source] of Object.entries(matrix.probes)) {
+      const page = await context.newPage();
+      const capture = {
+        media: "image/svg+xml" as const,
+        source: Buffer.from(source),
+        width: matrix.width,
+        height: matrix.height,
+        label: id,
+      };
+      const first = await measureOnlySvgText(page, capture);
+      const second = await measureOnlySvgText(page, capture);
+      await page.close();
+      if (JSON.stringify(first) !== JSON.stringify(second)) {
+        throw new Error(`${id}: text geometry is not deterministic`);
+      }
+      results[id] = first;
+      await writeFile(
+        join(matrix.outDir, `${id}.json`),
+        `${JSON.stringify(first, null, 2)}\n`,
+      );
+      console.log(`${id}: ${JSON.stringify(first)}`);
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+  return results;
 }

--- a/fixtures/web-first/text/README.md
+++ b/fixtures/web-first/text/README.md
@@ -1,15 +1,19 @@
 # The text cell suite
 
-Chromium-baked cells for the `<text>` slice on the SVG engine of record
-(`websem → rframe → n0`), gated byte-exact by
-[`crates/websem/tests/svg_text.rs`](../../../crates/websem/tests/svg_text.rs).
+Chromium-baked evidence for the `<text>` slice on the SVG engine of record
+(`websem → rframe → n0`). Nine Ahem cells are gated byte-exact by
+[`crates/websem/tests/svg_text.rs`](../../../crates/websem/tests/svg_text.rs);
+one real-font artifact witness is gated numerically, before rasterization, by
+[`crates/websem/tests/svg_text_geometry.rs`](../../../crates/websem/tests/svg_text_geometry.rs).
 The method these cells enforce is the ratified
 [text-oracle brief](../../../docs/wg/consolidation/text-oracle.md); this file
 states only how the suite is shaped.
 
-The suite currently has **nine** cells. Its manifest is a closed enumeration:
-the Rust gate rejects an unlisted SVG, duplicate source row, stale suite or
-baker hash, stale shared-capture hash, changed source, or changed oracle.
+The pixel suite currently has **nine** cells. The separate Rung-B geometry
+suite under [`geometry/`](./geometry/) has **one** witness. Both manifests are
+closed enumerations: the Rust gates reject an unlisted SVG, duplicate source
+row, stale suite or baker hash, stale shared-capture hash, changed source, or
+changed oracle.
 
 Text lives in its own suite rather than the primitive root, per the brief's
 corpus-growth law: the root is closed to text, probes are never committed,
@@ -47,7 +51,7 @@ both recorded verbatim in `oracle-bake.json`:
 | comparison | full RGBA, byte-exact — no tolerance is admissible here |
 | repeats | two captures per cell, byte-equal required |
 
-The baker imports the same hash-pinned
+Both bakers import the same hash-pinned
 [`chromium_capture.ts`](../chromium_capture.ts) module as scratch probes and
 the primitive baker. Text adds only its declared-font injection; it does not
 carry a second browser launch, context, viewport, network, or screenshot
@@ -111,6 +115,75 @@ fractional-translation frame and fail loudly in the committed text contract.
 Restoring the patrol returns primitive cells, all nine text cells, and the
 closed refusal register to green.
 
+## T2 real-font artifact geometry
+
+Rung B makes a different claim from the exact Ahem cells. Chromium's standard
+SVG text-query APIs grade the resolved run and character-cell geometry; they
+do not grade real-font pixels. Engine pixels are required only to be
+deterministic, non-empty for the witness, and identical between strict and
+best-effort admission. No real-font Chromium raster is an oracle here.
+
+The first witness uses the existing redistributable
+[`Allerta-Regular.ttf`](../../fonts/Allerta/Allerta-Regular.ttf), face index 0:
+16,248 bytes, SHA-256
+`16d6915227c7560725c037c9c93163cba5367c3ef4cf2ec12bf40b9eb2984a6b`, under
+the [SIL Open Font License 1.1](../../fonts/Allerta/OFL.txt) whose bytes are
+independently hash-pinned in `geometry/cases.json`. The source is the one LTR
+run `Hxi` at 5120px, middle-anchored so its 8600px advance starts at zero.
+
+Chromium 149.0.7827.55 directly reports total and substring length 8600;
+character advances 3745, 3400, and 1455; starts at 0, 3745, and 7145; baseline
+4080; and a logical character-cell top/height of -1205/6545. The immutable
+artifact matches every reported number exactly after promoting its binary32
+facts to binary64. Source indices in the browser record are UTF-16 code-unit
+indices, while artifact clusters are UTF-8 byte offsets; printable ASCII makes
+the mapping 0/1/2 on both sides.
+
+Chromium exposes no glyph identifier or outline-ink box. Those are therefore
+not described as browser measurements: the gate checks separately against the
+same pinned font bytes that glyphs `H`, `x`, and `i` are cmap ids 42, 88, and
+73, that the face has 1024 units per em, and that the shaped outline union is
+`(470, -4080, 7765, 4080)`. The resulting frame path has the corresponding
+translated bounds `(470, 0, 7765, 4080)`; no font fact crosses `rframe`.
+
+The numeric boundary is two-dimensional. Blink's SVG query projection
+encloses horizontal character boundaries on a 1/64 CSS-pixel grid and exposes
+vertical cells through integral fixed ascent/descent metrics. Scratch probes
+at 80, 85, 1000, and 5120px found both divergence classes: 80px preserves the
+horizontal values but not the vertical metrics, 85px and 1000px diverge on
+both, and 5120px is exact on both (measured, not celled except for the 5120px
+witness). At 1000px, for example, the artifact's first advance is
+731.4453125 while Chromium reports 731.453125 after enclosing it to 1/64, and
+the artifact ascent is 1032.2265625 while the character cell uses 1032.
+A separate Bungee 50px probe isolates the other leg: ascent/descent are already
+the integral 51/15, while the artifact's first 37.95 advance is exposed by
+Chromium as 37.953125. Both actual command admissions reach the 1/64 refusal
+(measured, not celled); the hash-pinned font is a negative-only gate identity,
+not a second positive oracle.
+
+That formerly admissible 1000px route now refuses by the stable
+`Chromium SVG text query` reason in strict admission and skips/degrades the
+same text node in best effort. Its refusal row is committed as
+`svg-text-geometry-grid`. A supporting scratch raster comparison found 8,310
+differing pixels at maximum channel delta 170 against Chromium before the
+guard; this is evidence of the unsafe route, not a real-font pixel-fidelity
+claim. Separate `fi` and `AV` probes in this selected face found no second
+shaping class (measured, not celled); ligature, kerning, offset, and broader
+cluster behavior remain the next text rung.
+
+Gate sensitivity is direct. Temporarily bypassing the query-geometry admission
+let both negative runs lower; `just gate` passed the unrelated 1,051 primitive
+cells and nine Ahem cells, then failed loudly in both the vertical-only Allerta
+80px and horizontal-only Bungee 50px contract tests. Restoring the admission
+returned the complete gate, including all 207 named refusal rows, to green.
+Independently changing the committed run length by exactly 1/64 made the
+exact-number comparison fail (`8600` versus `8600.015625`), and restoration
+returned it green. Re-registering the existing id/source was refused as
+immutable. Scratch source mutations remained discriminating: `Hxi` to `HxW`
+changed 715,311 Chromium pixels and middle to start anchoring changed 715,768,
+both at maximum channel delta 255 (measured, not celled and not used as a
+real-font pixel oracle).
+
 ## Tooling
 
 Run from `fixtures/web-first/`:
@@ -118,14 +191,19 @@ Run from `fixtures/web-first/`:
 ```sh
 just text-add <svg-text-id> <scratch-source>
 just text-bake
+just text-geometry-add <svg-text-id> <scratch-source> <scratch-font-facts>
+just text-geometry-bake
 just text-gate
 ```
 
 `text-add` refuses an existing source or manifest row and never writes an
 oracle. `text-bake` creates only missing oracles, verifies every existing one
 pixel-for-pixel, and refreshes hash provenance. `text-gate` is the focused
-exact-byte Rust gate; the broader `just gate` also runs it and the refusal
-register.
+Rust gate for both the exact pixels and artifact geometry; the broader
+`just gate` also runs it and the refusal register. `text-geometry-add` likewise
+refuses an existing source or oracle path, while `text-geometry-bake` creates
+only a missing JSON oracle and requires every existing numeric record to remain
+byte-identical.
 
 ## Re-baking
 

--- a/fixtures/web-first/text/bake_chromium.ts
+++ b/fixtures/web-first/text/bake_chromium.ts
@@ -29,6 +29,7 @@ import { PNG } from "pngjs";
 
 import {
   captureFirstSvg,
+  declareFontInSvg,
   deterministicContext,
   launchDeterministicChromium,
 } from "../chromium_capture";
@@ -55,20 +56,6 @@ const CAPTURE_MODULE = "../chromium_capture.ts";
 
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-/**
- * Declare the pinned face to the document, exactly as the host declares it
- * to the engine. The rule is injected as the root `<svg>`'s first child so
- * the committed source stays font-free.
- */
-function withFontDeclared(source: string, family: string, fontDataUrl: string): string {
-  const rule = `<style>@font-face{font-family:"${family}";src:url(${fontDataUrl});}</style>`;
-  const rootEnd = source.indexOf(">");
-  if (rootEnd < 0 || !source.slice(0, rootEnd).includes("<svg")) {
-    throw new Error("fixture must open with an <svg> root element");
-  }
-  return source.slice(0, rootEnd + 1) + rule + source.slice(rootEnd + 1);
 }
 
 function assertSamePixels(existing: Buffer, fresh: Buffer, id: string): void {
@@ -118,8 +105,6 @@ async function main(): Promise<void> {
         `${suite.font.path} (${fontDigest})`,
     );
   }
-  const fontDataUrl = `data:font/ttf;base64,${fontBytes.toString("base64")}`;
-
   const scriptBytes = await readFile(SCRIPT_PATH);
   const captureBytes = await readFile(join(DIR, CAPTURE_MODULE));
   const browser = await launchDeterministicChromium();
@@ -131,10 +116,10 @@ async function main(): Promise<void> {
     for (const fixture of suite.cases) {
       const sourcePath = join(DIR, fixture.source);
       const sourceBytes = await readFile(sourcePath);
-      const declared = withFontDeclared(
+      const declared = declareFontInSvg(
         sourceBytes.toString("utf8"),
         suite.font.family,
-        fontDataUrl,
+        fontBytes,
       );
 
       const page = await context.newPage();

--- a/fixtures/web-first/text/geometry/add_case.py
+++ b/fixtures/web-first/text/geometry/add_case.py
@@ -10,6 +10,7 @@ ids/source mappings, and outline ink bounds.
 """
 
 import argparse
+import fcntl
 import json
 import math
 import re
@@ -45,7 +46,9 @@ def main() -> None:
     if not ID_PATTERN.fullmatch(args.id):
         sys.exit(f"refused: {args.id!r} is not an svg-text-* kebab-case id")
 
-    suite = json.loads(MANIFEST.read_text())
+    manifest_file = MANIFEST.open("r+", encoding="utf-8")
+    fcntl.flock(manifest_file.fileno(), fcntl.LOCK_EX)
+    suite = json.load(manifest_file)
     source = Path(args.source).read_text()
     if "<!DOCTYPE" in source or "<script" in source or "@font-face" in source:
         sys.exit("refused: geometry sources contain no doctype, script, or font bytes")
@@ -168,8 +171,15 @@ def main() -> None:
 
     suite["cases"].append(case)
     suite["cases"].sort(key=lambda row: row["id"])
-    fixture.write_text(source)
-    MANIFEST.write_text(json.dumps(suite, indent=2) + "\n")
+    with fixture.open("x", encoding="utf-8") as fixture_file:
+        fixture_file.write(source)
+    manifest_file.seek(0)
+    json.dump(suite, manifest_file, indent=2)
+    manifest_file.write("\n")
+    manifest_file.truncate()
+    manifest_file.flush()
+    fcntl.flock(manifest_file.fileno(), fcntl.LOCK_UN)
+    manifest_file.close()
     print(f"added {args.id}; run `just text-geometry-bake`")
 
 

--- a/fixtures/web-first/text/geometry/add_case.py
+++ b/fixtures/web-first/text/geometry/add_case.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Register one real-font SVG text geometry witness without overwriting.
+
+Usage:
+    python3 add_case.py <id> --source <svg> --facts <json>
+
+The source must use the suite's canonical one-run shape. `facts` records the
+font-derived evidence Chromium cannot expose: units-per-em, direct cmap glyph
+ids/source mappings, and outline ink bounds.
+"""
+
+import argparse
+import json
+import math
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+DIR = Path(__file__).resolve().parent
+MANIFEST = DIR / "cases.json"
+SVG_NS = "http://www.w3.org/2000/svg"
+ID_PATTERN = re.compile(r"^svg-text-[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def canonical(case: dict) -> str:
+    return (
+        f'<svg xmlns="{SVG_NS}" width="{case["width"]}" height="{case["height"]}">\n'
+        f'  <text x="{case["x"]}" y="{case["y"]}" '
+        f'text-anchor="{case["text_anchor"]}" '
+        f'font-family="{case["font_family"]}" '
+        f'font-size="{case["font_size"]}" fill="{case["fill"]}">'
+        f'{case["text"]}</text>\n'
+        "</svg>\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("id")
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--facts", required=True)
+    args = parser.parse_args()
+
+    if not ID_PATTERN.fullmatch(args.id):
+        sys.exit(f"refused: {args.id!r} is not an svg-text-* kebab-case id")
+
+    suite = json.loads(MANIFEST.read_text())
+    source = Path(args.source).read_text()
+    if "<!DOCTYPE" in source or "<script" in source or "@font-face" in source:
+        sys.exit("refused: geometry sources contain no doctype, script, or font bytes")
+    try:
+        root = ET.fromstring(source)
+    except ET.ParseError as error:
+        sys.exit(f"refused: source is not XML: {error}")
+    if root.tag != f"{{{SVG_NS}}}svg" or set(root.attrib) != {"width", "height"}:
+        sys.exit("refused: expected one width/height SVG root")
+    children = list(root)
+    if len(children) != 1 or children[0].tag != f"{{{SVG_NS}}}text":
+        sys.exit("refused: expected exactly one direct <text> child")
+    text = children[0]
+    required = {"x", "y", "text-anchor", "font-family", "font-size", "fill"}
+    if set(text.attrib) != required or list(text):
+        sys.exit("refused: the one text run has only the canonical attributes and no children")
+    content = text.text or ""
+    if not content or any(not (" " <= character <= "~") for character in content):
+        sys.exit("refused: the rung-B witness is non-empty printable ASCII")
+    if " ".join(content.split()) != content:
+        sys.exit("refused: source text must already be in canonical collapsed-space form")
+    if text.attrib["font-family"] != suite["font"]["family"]:
+        sys.exit("refused: the source must request the suite's exact family")
+    if text.attrib["text-anchor"] not in {"start", "middle", "end"}:
+        sys.exit("refused: text-anchor must be start, middle, or end")
+
+    try:
+        width = int(root.attrib["width"])
+        height = int(root.attrib["height"])
+        numbers = {
+            name: float(text.attrib[name]) for name in ("x", "y", "font-size")
+        }
+    except ValueError:
+        sys.exit("refused: dimensions and geometry must be plain finite numbers")
+    if (
+        width <= 0
+        or height <= 0
+        or not all(math.isfinite(value) for value in numbers.values())
+        or numbers["font-size"] <= 0
+    ):
+        sys.exit("refused: dimensions and finite font size must be positive")
+
+    facts = json.loads(Path(args.facts).read_text())
+    if not isinstance(facts, dict) or set(facts) != {
+        "units_per_em",
+        "glyphs",
+        "ink_bounds",
+    }:
+        sys.exit("refused: facts must name units_per_em, glyphs, and ink_bounds")
+    units_per_em = facts["units_per_em"]
+    if (
+        not isinstance(units_per_em, int)
+        or isinstance(units_per_em, bool)
+        or not 1 <= units_per_em <= 65535
+    ):
+        sys.exit("refused: units_per_em must be a positive 16-bit integer")
+    if not isinstance(facts["glyphs"], list) or len(facts["glyphs"]) != len(content):
+        sys.exit("refused: rung B requires one direct cmap glyph fact per ASCII byte")
+    for index, (character, glyph) in enumerate(zip(content, facts["glyphs"])):
+        glyph_id = glyph.get("glyph_id") if isinstance(glyph, dict) else None
+        expected = {
+            "source_utf8_byte": index,
+            "source_utf16_index": index,
+            "scalar": character,
+            "glyph_id": glyph_id,
+            "cluster": index,
+        }
+        if (
+            glyph != expected
+            or not isinstance(glyph_id, int)
+            or isinstance(glyph_id, bool)
+            or not 1 <= glyph_id <= 65535
+        ):
+            sys.exit(f"refused: glyph fact {index} is not the direct source mapping")
+    ink_bounds = facts["ink_bounds"]
+    if not isinstance(ink_bounds, dict) or set(ink_bounds) != {
+        "x",
+        "y",
+        "width",
+        "height",
+    }:
+        sys.exit("refused: ink_bounds must be one x/y/width/height rectangle")
+    if any(
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+        for value in ink_bounds.values()
+    ) or ink_bounds["width"] <= 0 or ink_bounds["height"] <= 0:
+        sys.exit("refused: ink_bounds must contain finite positive extents")
+
+    case = {
+        "id": args.id,
+        "source": f"{args.id}.svg",
+        "oracle": f"chromium/{args.id}.json",
+        "width": width,
+        "height": height,
+        "text": content,
+        "x": text.attrib["x"],
+        "y": text.attrib["y"],
+        "text_anchor": text.attrib["text-anchor"],
+        "font_family": text.attrib["font-family"],
+        "font_size": text.attrib["font-size"],
+        "fill": text.attrib["fill"],
+        "font_facts": facts,
+    }
+    if source != canonical(case):
+        sys.exit("refused: source bytes are not in the canonical geometry-fixture shape")
+
+    fixture = DIR / case["source"]
+    oracle = DIR / case["oracle"]
+    if fixture.exists() or oracle.exists():
+        sys.exit("refused: an existing geometry source or oracle is immutable")
+    if any(
+        row["id"] == args.id
+        or row["source"] == case["source"]
+        or row["oracle"] == case["oracle"]
+        for row in suite["cases"]
+    ):
+        sys.exit("refused: id, source, or oracle is already registered")
+
+    suite["cases"].append(case)
+    suite["cases"].sort(key=lambda row: row["id"])
+    fixture.write_text(source)
+    MANIFEST.write_text(json.dumps(suite, indent=2) + "\n")
+    print(f"added {args.id}; run `just text-geometry-bake`")
+
+
+if __name__ == "__main__":
+    main()

--- a/fixtures/web-first/text/geometry/bake_chromium.ts
+++ b/fixtures/web-first/text/geometry/bake_chromium.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env -S pnpm --filter @grida/reftest exec tsx
+/** Bake exact SVGTextContentElement geometry for the rung-B text suite. */
+
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { exit } from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  declareFontInSvg,
+  deterministicContext,
+  launchDeterministicChromium,
+  measureOnlySvgText,
+} from "../../chromium_capture";
+
+interface Case {
+  id: string;
+  source: string;
+  oracle: string;
+  width: number;
+  height: number;
+  text: string;
+  x: string;
+  y: string;
+  text_anchor: string;
+  font_family: string;
+  font_size: string;
+}
+
+interface Suite {
+  schema_version: number;
+  font: {
+    family: string;
+    path: string;
+    sha256: string;
+    face_index: number;
+    license: string;
+    license_sha256: string;
+  };
+  cases: Case[];
+}
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const DIR = dirname(SCRIPT_PATH);
+const SUITE_PATH = join(DIR, "cases.json");
+const OUT_MANIFEST = join(DIR, "oracle-bake.json");
+const CAPTURE_MODULE = "../../chromium_capture.ts";
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function main(): Promise<void> {
+  const suiteBytes = await readFile(SUITE_PATH);
+  const suite = JSON.parse(suiteBytes.toString("utf8")) as Suite;
+  if (suite.schema_version !== 1 || suite.cases.length === 0) {
+    throw new Error("unsupported or empty text geometry suite");
+  }
+  if (suite.font.face_index !== 0) {
+    throw new Error("the inline @font-face geometry baker admits face index 0 only");
+  }
+  let previous = "";
+  const identities = new Set<string>();
+  for (const fixture of suite.cases) {
+    if (fixture.id <= previous) {
+      throw new Error("geometry cases must have unique ids in sorted order");
+    }
+    for (const identity of [fixture.id, fixture.source, fixture.oracle]) {
+      if (identities.has(identity)) {
+        throw new Error(`${fixture.id}: duplicate id, source, or oracle`);
+      }
+      identities.add(identity);
+    }
+    previous = fixture.id;
+  }
+
+  const fontBytes = await readFile(join(DIR, suite.font.path));
+  const fontDigest = sha256(fontBytes);
+  if (fontDigest !== suite.font.sha256) {
+    throw new Error(`declared font digest does not match ${suite.font.path}`);
+  }
+  const licenseBytes = await readFile(join(DIR, suite.font.license));
+  if (sha256(licenseBytes) !== suite.font.license_sha256) {
+    throw new Error(`declared license digest does not match ${suite.font.license}`);
+  }
+
+  const scriptBytes = await readFile(SCRIPT_PATH);
+  const captureBytes = await readFile(join(DIR, CAPTURE_MODULE));
+  const browser = await launchDeterministicChromium();
+  const browserVersion = browser.version();
+  const context = await deterministicContext(browser, {
+    javaScriptEnabled: true,
+  });
+  const records: unknown[] = [];
+  try {
+    for (const fixture of suite.cases) {
+      const sourcePath = join(DIR, fixture.source);
+      const sourceBytes = await readFile(sourcePath);
+      const source = sourceBytes.toString("utf8");
+      if (source.includes("<script") || source.includes("@font-face")) {
+        throw new Error(`${fixture.id}: fixture carries executable code or font bytes`);
+      }
+      const declared = declareFontInSvg(source, suite.font.family, fontBytes);
+      const page = await context.newPage();
+      const capture = {
+        media: "image/svg+xml" as const,
+        source: Buffer.from(declared),
+        width: fixture.width,
+        height: fixture.height,
+        label: fixture.id,
+      };
+      const first = await measureOnlySvgText(page, capture);
+      const second = await measureOnlySvgText(page, capture);
+      await page.close();
+      if (JSON.stringify(first) !== JSON.stringify(second)) {
+        throw new Error(`${fixture.id}: Chromium geometry is not deterministic`);
+      }
+      if (
+        !first.font_ready ||
+        first.text_content !== fixture.text ||
+        first.computed_font_family !== suite.font.family ||
+        first.computed_font_size !== `${fixture.font_size}px` ||
+        first.computed_text_anchor !== fixture.text_anchor
+      ) {
+        throw new Error(
+          `${fixture.id}: declared font/text posture did not take effect: ${JSON.stringify(first)}`,
+        );
+      }
+
+      const oracle = {
+        schema_version: 1,
+        kind: "chromium-svg-text-geometry",
+        measurement: first,
+      };
+      const fresh = Buffer.from(`${JSON.stringify(oracle, null, 2)}\n`);
+      const oraclePath = join(DIR, fixture.oracle);
+      if (existsSync(oraclePath)) {
+        const existing = await readFile(oraclePath);
+        if (!existing.equals(fresh)) {
+          throw new Error(`${fixture.id}: Chromium geometry differs from the committed oracle`);
+        }
+      } else {
+        await mkdir(dirname(oraclePath), { recursive: true });
+        await writeFile(oraclePath, fresh, { flag: "wx" });
+        console.log(`created ${fixture.oracle}`);
+      }
+      records.push({
+        id: fixture.id,
+        source: fixture.source,
+        source_sha256: sha256(sourceBytes),
+        oracle: fixture.oracle,
+        oracle_sha256: sha256(await readFile(oraclePath)),
+        width: fixture.width,
+        height: fixture.height,
+      });
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  const manifest = {
+    schema_version: 1,
+    kind: "chromium-svg-text-geometry-oracle",
+    browser_version: browserVersion,
+    suite: "cases.json",
+    suite_sha256: sha256(suiteBytes),
+    bake_script: "bake_chromium.ts",
+    bake_script_sha256: sha256(scriptBytes),
+    capture_module: CAPTURE_MODULE,
+    capture_module_sha256: sha256(captureBytes),
+    font: {
+      family: suite.font.family,
+      sha256: suite.font.sha256,
+      face_index: suite.font.face_index,
+      license_sha256: suite.font.license_sha256,
+      declaration: "inline @font-face injected by the shared capture module",
+    },
+    capture_policy: {
+      viewport: "the fixture's declared size as the initial viewport",
+      device_scale_factor: 1,
+      javascript: "enabled only for harness-owned SVGTextContentElement measurement; fixtures contain no script",
+      network: "aborted",
+      index_unit: "UTF-16 code unit, per SVGTextContentElement",
+      apis: [
+        "getNumberOfChars",
+        "getComputedTextLength",
+        "getSubStringLength",
+        "getStartPositionOfChar",
+        "getEndPositionOfChar",
+        "getExtentOfChar",
+        "getRotationOfChar",
+      ],
+      comparison: "JSON number -> IEEE-754 binary64; artifact binary32 promoted to binary64; exact equality, no tolerance",
+      fresh_measurements_per_case: 2,
+    },
+    records,
+  };
+  await writeFile(OUT_MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`baked ${records.length} text geometry witnesses with ${browserVersion}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  exit(1);
+});

--- a/fixtures/web-first/text/geometry/cases.json
+++ b/fixtures/web-first/text/geometry/cases.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "font": {
+    "family": "Allerta",
+    "path": "../../../fonts/Allerta/Allerta-Regular.ttf",
+    "sha256": "16d6915227c7560725c037c9c93163cba5367c3ef4cf2ec12bf40b9eb2984a6b",
+    "face_index": 0,
+    "license": "../../../fonts/Allerta/OFL.txt",
+    "license_sha256": "f81e6bb77d9f3f302d6264545b8abcd09dda0827fb4b62cf811ed59d6fd3a968"
+  },
+  "cases": [
+    {
+      "id": "svg-text-allerta-geometry",
+      "source": "svg-text-allerta-geometry.svg",
+      "oracle": "chromium/svg-text-allerta-geometry.json",
+      "width": 1200,
+      "height": 500,
+      "text": "Hxi",
+      "x": "4300",
+      "y": "4080",
+      "text_anchor": "middle",
+      "font_family": "Allerta",
+      "font_size": "5120",
+      "fill": "#111827",
+      "font_facts": {
+        "units_per_em": 1024,
+        "glyphs": [
+          {
+            "source_utf8_byte": 0,
+            "source_utf16_index": 0,
+            "scalar": "H",
+            "glyph_id": 42,
+            "cluster": 0
+          },
+          {
+            "source_utf8_byte": 1,
+            "source_utf16_index": 1,
+            "scalar": "x",
+            "glyph_id": 88,
+            "cluster": 1
+          },
+          {
+            "source_utf8_byte": 2,
+            "source_utf16_index": 2,
+            "scalar": "i",
+            "glyph_id": 73,
+            "cluster": 2
+          }
+        ],
+        "ink_bounds": {
+          "x": 470.0,
+          "y": -4080.0,
+          "width": 7765.0,
+          "height": 4080.0
+        }
+      }
+    }
+  ]
+}

--- a/fixtures/web-first/text/geometry/chromium/svg-text-allerta-geometry.json
+++ b/fixtures/web-first/text/geometry/chromium/svg-text-allerta-geometry.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "kind": "chromium-svg-text-geometry",
+  "measurement": {
+    "text_content": "Hxi",
+    "computed_font_family": "Allerta",
+    "computed_font_size": "5120px",
+    "computed_text_anchor": "middle",
+    "font_ready": true,
+    "number_of_chars": 3,
+    "computed_text_length": 8600,
+    "substring_length": 8600,
+    "characters": [
+      {
+        "utf16_code_unit": 72,
+        "substring_length": 3745,
+        "start": {
+          "x": 0,
+          "y": 4080
+        },
+        "end": {
+          "x": 3745,
+          "y": 4080
+        },
+        "extent": {
+          "x": 0,
+          "y": -1205,
+          "width": 3745,
+          "height": 6545
+        },
+        "rotation": 0
+      },
+      {
+        "utf16_code_unit": 120,
+        "substring_length": 3400,
+        "start": {
+          "x": 3745,
+          "y": 4080
+        },
+        "end": {
+          "x": 7145,
+          "y": 4080
+        },
+        "extent": {
+          "x": 3745,
+          "y": -1205,
+          "width": 3400,
+          "height": 6545
+        },
+        "rotation": 0
+      },
+      {
+        "utf16_code_unit": 105,
+        "substring_length": 1455,
+        "start": {
+          "x": 7145,
+          "y": 4080
+        },
+        "end": {
+          "x": 8600,
+          "y": 4080
+        },
+        "extent": {
+          "x": 7145,
+          "y": -1205,
+          "width": 1455,
+          "height": 6545
+        },
+        "rotation": 0
+      }
+    ]
+  }
+}

--- a/fixtures/web-first/text/geometry/oracle-bake.json
+++ b/fixtures/web-first/text/geometry/oracle-bake.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "kind": "chromium-svg-text-geometry-oracle",
+  "browser_version": "149.0.7827.55",
+  "suite": "cases.json",
+  "suite_sha256": "751b945bf5d084c633071bc9a1dfc46e38dc9154f4449ec26b18c6afc42c5c9c",
+  "bake_script": "bake_chromium.ts",
+  "bake_script_sha256": "c77d4d047d93357958382b64d52eafb6fb03311c699233e7c34ead4e306b3196",
+  "capture_module": "../../chromium_capture.ts",
+  "capture_module_sha256": "c66ee93e4f96d4f5c169254181d7cda14bb4254e07d65f64dec7f32f5bdcb296",
+  "font": {
+    "family": "Allerta",
+    "sha256": "16d6915227c7560725c037c9c93163cba5367c3ef4cf2ec12bf40b9eb2984a6b",
+    "face_index": 0,
+    "license_sha256": "f81e6bb77d9f3f302d6264545b8abcd09dda0827fb4b62cf811ed59d6fd3a968",
+    "declaration": "inline @font-face injected by the shared capture module"
+  },
+  "capture_policy": {
+    "viewport": "the fixture's declared size as the initial viewport",
+    "device_scale_factor": 1,
+    "javascript": "enabled only for harness-owned SVGTextContentElement measurement; fixtures contain no script",
+    "network": "aborted",
+    "index_unit": "UTF-16 code unit, per SVGTextContentElement",
+    "apis": [
+      "getNumberOfChars",
+      "getComputedTextLength",
+      "getSubStringLength",
+      "getStartPositionOfChar",
+      "getEndPositionOfChar",
+      "getExtentOfChar",
+      "getRotationOfChar"
+    ],
+    "comparison": "JSON number -> IEEE-754 binary64; artifact binary32 promoted to binary64; exact equality, no tolerance",
+    "fresh_measurements_per_case": 2
+  },
+  "records": [
+    {
+      "id": "svg-text-allerta-geometry",
+      "source": "svg-text-allerta-geometry.svg",
+      "source_sha256": "efe59a9377fd45559ab9cd5299b55a9e0a2b15b841bf85030a0309d619a4078e",
+      "oracle": "chromium/svg-text-allerta-geometry.json",
+      "oracle_sha256": "5bdd572e763f87fae10cccfc9b5e5cb3ad57a41ee8bcbd10c3a05c2d7af4a385",
+      "width": 1200,
+      "height": 500
+    }
+  ]
+}

--- a/fixtures/web-first/text/geometry/svg-text-allerta-geometry.svg
+++ b/fixtures/web-first/text/geometry/svg-text-allerta-geometry.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="500">
+  <text x="4300" y="4080" text-anchor="middle" font-family="Allerta" font-size="5120" fill="#111827">Hxi</text>
+</svg>

--- a/fixtures/web-first/text/oracle-bake.json
+++ b/fixtures/web-first/text/oracle-bake.json
@@ -5,9 +5,9 @@
   "suite": "cases.json",
   "suite_sha256": "e759912cc352c3277f4a5b5c5a37cc19e8860e3146ede5291276473f5c634aff",
   "bake_script": "bake_chromium.ts",
-  "bake_script_sha256": "d4bb830561512c5df8f9a85004a8ae4d83a95a3089514877b7ddc7e9608a79c2",
+  "bake_script_sha256": "9999ad1e574d2e00fedf09fb8b43dc44202a45f46cc010482ac8b26e11202571",
   "capture_module": "../chromium_capture.ts",
-  "capture_module_sha256": "15ba5c3156f3ed0bfd0f32b6ad773e1d228c0f678396db08c8de1d972cf5bced",
+  "capture_module_sha256": "c66ee93e4f96d4f5c169254181d7cda14bb4254e07d65f64dec7f32f5bdcb296",
   "font": {
     "family": "Ahem",
     "sha256": "b719ecb31c5b21fc573c03f6421c74ac63c271a5a3ff841e34f9705fb94b8448",

--- a/fixtures/web-first/unsupported/README.md
+++ b/fixtures/web-first/unsupported/README.md
@@ -60,6 +60,7 @@ The scannable, generated view of this register (beside the baked cells) is
 | `svg-text-font-size-comment-string.svg` | Refuse CSS that mixes quoted text and comment delimiters before a coarse authored-source scan can misclassify it. Chromium treats a quoted `/*` as string data and applies the later `5119px`; the former patrol erased the tail, admitted Stylo's `5120px`, and changed 149 pixels at maximum delta 255 in both admissions (measured, not celled). |
 | `svg-text-font-size-source.svg` | Refuse a direct size changed by pinned Stylo quantization before the local numeric check. Authored `5119px` became computed `5120px` and changed 149 Chromium pixels at maximum channel delta 255 while both admissions formerly rendered without a declaration (measured, not celled). |
 | `svg-text-final-ctm.svg` | Enforce the numeric domain on the composed local-to-device mapping, after root `viewBox`, ancestors, the text transform, and `<use>` placement. A fractional translation formerly changed 40 pixels at maximum delta 128 while both admissions rendered silently; non-identity linear maps share the stable final-CTM refusal (measured, not celled). |
+| `svg-text-geometry-grid.svg` | Refuse a real-font artifact whose geometry Chromium's SVG text-query projection would normalize differently. Blink encloses horizontal character boundaries on a 1/64 CSS-pixel grid and exposes vertical cells through integral fixed ascent/descent metrics; the 1000px Allerta witness misses both grids (731.4453125 artifact advance versus 731.453125 measured character width, and 1032.2265625 artifact ascent versus 1032 in the browser cell). Strict refuses and best effort skips/degrades the same text node by the stable `Chromium SVG text query` reason (measured, not celled as a positive case). |
 | `svg-text-css-layout.svg` · `svg-text-font-shorthand.svg` | Refuse cascaded text/font semantics the v0 single-run artifact does not carry. The direct, ancestor, and stylesheet routes are text-scoped and conservative: the one Stylo cascade still owns admitted values, while this patrol supplies no matcher. Chromium's italic shorthand and letter-spacing witnesses changed 68 and 200 pixels at maximum delta 255 before the guard (measured, not celled). |
 | `svg-text-undeclared-font.svg` | Text is admitted only against the rung's one declared font identity. An undeclared family refuses at the text element instead of silently substituting different glyph metrics. |
 | `svg-text-tspan.svg` | `<tspan>` retains its own named text-residue refusal: the admitted text run is one direct text-node sequence, so nested positioning and styling cannot be silently flattened into it. |
@@ -237,5 +238,6 @@ coordinate split adds eight coordinate rows and one zero-area gradient row,
 and its opacity audit adds one line-coverage row, taking that rung's register
 to 198. The opacity structural-pass recovery later graduates that row, leaving
 197. The text safety fence adds nine focused size-source, final-mapping,
-inherited-anchor, and unconsumed-layout rows, taking the current register to
-206.)
+inherited-anchor, and unconsumed-layout rows, taking the register to 206. The
+real-font artifact-geometry rung adds the query-grid patrol, taking the current
+register to 207.)

--- a/fixtures/web-first/unsupported/svg-text-geometry-grid.svg
+++ b/fixtures/web-first/unsupported/svg-text-geometry-grid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <text x="0" y="1000" text-anchor="start" font-family="Allerta" font-size="1000" fill="#000">Hxi</text>
+</svg>


### PR DESCRIPTION
## Verdict

T2 is **EXERCISED**, with no checklist closure.

This adds the first real-font Rung-B geometry witness for SVG text. One exact,
declared Allerta Regular face shapes `Hxi` at 5120px; Chromium's standard SVG
text-query APIs grade the browser-visible artifact geometry by exact number,
while direct cmap glyph ids, clusters, units-per-em, and outline ink remain
separately pinned to the exact font bytes. Real-font pixels are tested only for
the engine laws (determinism, nonempty paint, strict=best); this PR makes no
Chromium real-font pixel claim.

## Measured crux

- Chromium 149.0.7827.55 reports advances `3745 / 3400 / 1455`, total `8600`,
  baseline `4080`, and logical cells at `y=-1205`, height `6545` for the
  committed Allerta witness. The resolved artifact matches every recorded
  browser-visible number exactly after binary32-to-binary64 promotion.
- Chromium's SVG query projection has two independent normalization legs:
  horizontal character boundaries are enclosed on a 1/64 CSS-pixel grid, and
  vertical cells expose integral fixed ascent/descent metrics.
- Allerta at 80px isolates the vertical leg. Bungee at 50px isolates the
  horizontal leg. Both now refuse before outline lowering instead of silently
  emitting geometry different from Chromium's query result.
- The prior 1000px Allerta route was a silent mismatch: artifact first advance
  `731.4453125` versus Chromium `731.453125`, and artifact ascent
  `1032.2265625` versus Chromium `1032`.
- Sampled `fi` and `AV` controls found no second shaping divergence in the
  selected face (measured, not celled); wider shaping remains T3.

The primitive corpus remains 1,051 Chromium-baked cells plus 16 sampled
frames. The Ahem text suite remains nine exact pixel cells; the new Allerta
suite adds one exact-number geometry witness. The named refusal register moves
from 206 to 207.

## Gate sensitivity

- Removing the query-geometry patrol let both isolated negative routes lower;
  `just gate` then failed loudly in the Allerta vertical-only and Bungee
  horizontal-only tests. Restoring it returned the complete gate to green.
- Perturbing the committed run length from `8600` to `8600.015625` failed the
  exact artifact comparison; restoring it returned the test to green.
- Attempting to re-add the existing geometry case was refused by the immutable
  source/oracle registration tool.

## Verification

- `cargo test -p textlayout -p websem -p rframe -p n0 -p n0_cli`
- `cargo test -p websem` after refreshing the shared-capture provenance of all
  16 unchanged animation frames
- `cargo clippy --no-deps --workspace --exclude grida-canvas-wasm -- -D warnings`
- `cargo fmt --all -- --check`
- `just gate`; `just status`
- all primitive, Ahem text, animation, and geometry Chromium bakes reverified
  without replacing an oracle
- `pnpm fmt:check`; `pnpm exec oxlint --deny-warnings`
- `pnpm --filter www types:check`; `pnpm --filter www build`
- `pnpm --filter @grida/reftest typecheck`; build; test (51 passed, 1 skipped)
- Cargo.lock additions-only controls and branch gate
- docs links/rendering through the production `www` build
- pre-PR OSS audit and `git diff --check`

No Workflow runner is exposed in this environment, so
`.agents/workflows/verify-rung.js` could not be invoked. I reproduced its
independent roles by hand:

- **TICK/LAW:** no checklist checkbox changes; no CSS matcher, `rframe`, FLIP,
  score, or unrelated contract change; unsupported geometry refuses by a
  stable name in both admissions.
- **REPRO:** exact committed numbers fail when perturbed; both independent
  patrol legs fail when bypassed; restoration re-gates green.

Refs gridaco/nothing#69.
